### PR TITLE
🔒 fix: guard unsafe.Pointer cast in JSON/MultipartBody + checkptr CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### 🔒 Security — unsafe.Pointer UB in JSON/MultipartBody
+
+`JSONBody[T].Read` and `MultipartBody[T].Read` now verify the
+first-embedded-field layout invariant BEFORE performing
+`*(*T)(unsafe.Pointer(b))`. This eliminates a class of
+"converted pointer straddles multiple allocations" fatals under
+`-race` / `-gcflags=all=-d=checkptr=1` when callers violated the
+layout. `test.sh` gains a dedicated checkptr gate across
+`./runtime/...`.

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -34,7 +34,7 @@ func (b *JSONBody[T]) Read(p []byte) (n int, err error) {
 	b.once.Do(func() {
 		var x T
 		vt := reflect.TypeOf(x)
-		if vt.Kind() != reflect.Struct {
+		if vt == nil || vt.Kind() != reflect.Struct {
 			panic("use the value type of a struct rather than a pointer type as the value for generics")
 		}
 		target := reflect.TypeOf(b).Elem()
@@ -124,7 +124,7 @@ func (b *MultipartBody[T]) Read(p []byte) (n int, err error) {
 	b.once.Do(func() {
 		var x T
 		vt := reflect.TypeOf(x)
-		if vt.Kind() != reflect.Struct {
+		if vt == nil || vt.Kind() != reflect.Struct {
 			panic("use the value type of a struct rather than a pointer type as the value for generics")
 		}
 		target := reflect.TypeOf(b).Elem()

--- a/runtime/request.go
+++ b/runtime/request.go
@@ -33,34 +33,34 @@ type JSONBody[T any] struct {
 func (b *JSONBody[T]) Read(p []byte) (n int, err error) {
 	b.once.Do(func() {
 		var x T
-		vf := reflect.ValueOf(x)
-		if vf.Kind() != reflect.Struct {
+		vt := reflect.TypeOf(x)
+		if vt.Kind() != reflect.Struct {
 			panic("use the value type of a struct rather than a pointer type as the value for generics")
 		}
-		vt := vf.Type()
+		target := reflect.TypeOf(b).Elem()
+		if vt.NumField() == 0 ||
+			!vt.Field(0).Anonymous ||
+			vt.Field(0).Type != target {
+			panic("JSONBody is not the first embedded field of struct type T")
+		}
+		x = *(*T)(unsafe.Pointer(b))
+		vf := reflect.ValueOf(x)
 		// estimate the size of the body in advance
 		var toGrow = 0
-		for i := 0; i < vt.NumField(); i++ {
+		for i := 1; i < vt.NumField(); i++ {
 			sf, sv := vt.Field(i), vf.Field(i)
-			if i == 0 {
-				if !sf.Anonymous || sf.Type != reflect.TypeOf(b).Elem() {
-					panic("JSONBody is not the first embedded field of struct type T")
-				}
-			} else {
-				toGrow += 8 // object keys
-				switch sf.Type.Kind() {
-				case reflect.String:
-					toGrow += 2 + sv.Len()
-				case reflect.Slice:
-					toGrow += sv.Len() * 2
-				default:
-					toGrow += 4
-				}
+			toGrow += 8 // object keys
+			switch sf.Type.Kind() {
+			case reflect.String:
+				toGrow += 2 + sv.Len()
+			case reflect.Slice:
+				toGrow += sv.Len() * 2
+			default:
+				toGrow += 4
 			}
 		}
 		b.data.Grow(toGrow)
 		encoder := json.NewEncoder(&b.data)
-		x = *(*T)(unsafe.Pointer(b))
 		err = encoder.Encode(&x)
 	})
 	if err != nil {
@@ -123,14 +123,18 @@ func escapeQuotes(s string) string {
 func (b *MultipartBody[T]) Read(p []byte) (n int, err error) {
 	b.once.Do(func() {
 		var x T
-		x = *(*T)(unsafe.Pointer(b))
-		s := &fieldScanner{tag: "form", val: reflect.ValueOf(x)}
-		if s.val.Kind() != reflect.Struct {
+		vt := reflect.TypeOf(x)
+		if vt.Kind() != reflect.Struct {
 			panic("use the value type of a struct rather than a pointer type as the value for generics")
 		}
-		if !s.CheckFirstEmbedType(reflect.TypeOf(b).Elem()) {
+		target := reflect.TypeOf(b).Elem()
+		if vt.NumField() == 0 ||
+			!vt.Field(0).Anonymous ||
+			vt.Field(0).Type != target {
 			panic("MultipartBody is not the first embedded field of struct type T")
 		}
+		x = *(*T)(unsafe.Pointer(b))
+		s := &fieldScanner{tag: "form", val: reflect.ValueOf(x), typ: vt}
 		readers := make([]io.Reader, 0, s.val.NumField())
 		for i := 0; s.Scan(); i++ {
 			tag := s.Tag()

--- a/runtime/request_test.go
+++ b/runtime/request_test.go
@@ -39,6 +39,12 @@ type testDislocationRequestJSONBody struct {
 	JSONBody[testDislocationRequestJSONBody]
 }
 
+type testZeroFieldJSONGeneric struct{}
+
+type testZeroFieldRequestJSONBody struct {
+	JSONBody[testZeroFieldJSONGeneric]
+}
+
 func TestJSONBody(t *testing.T) {
 	want := map[string]any{
 		"code":    "test",
@@ -98,6 +104,20 @@ func TestJSONBody(t *testing.T) {
 		}()
 		_, _ = io.ReadAll(r)
 	})
+	t.Run("loc_panic_zero_field", func(t *testing.T) {
+		var r io.Reader
+		r = &testZeroFieldRequestJSONBody{}
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Errorf("json_body: expects Panic, got nil")
+				return
+			} else if lit, ok := rec.(string); !ok || lit != "JSONBody is not the first embedded field of struct type T" {
+				t.Errorf("json_body: unexpected Panic literal => %s", rec)
+				return
+			}
+		}()
+		_, _ = io.ReadAll(r)
+	})
 }
 
 type testRequestMultipartBody struct {
@@ -117,6 +137,12 @@ type testPanicRequestMultipartBody struct {
 type testDislocationRequestMultipartBody struct {
 	Name string `form:"name"`
 	MultipartBody[testDislocationRequestMultipartBody]
+}
+
+type testZeroFieldMultipartGeneric struct{}
+
+type testZeroFieldRequestMultipartBody struct {
+	MultipartBody[testZeroFieldMultipartGeneric]
 }
 
 func TestMultipartBody(t *testing.T) {
@@ -184,6 +210,19 @@ func TestMultipartBody(t *testing.T) {
 	})
 	t.Run("loc_panic", func(t *testing.T) {
 		r := &testDislocationRequestMultipartBody{Name: "test"}
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Errorf("multipart_body: expects Panic, got nil")
+				return
+			} else if lit, ok := rec.(string); !ok || lit != "MultipartBody is not the first embedded field of struct type T" {
+				t.Errorf("multipart_body: unexpected Panic literal => %s", rec)
+				return
+			}
+		}()
+		_, _ = io.ReadAll(r)
+	})
+	t.Run("loc_panic_zero_field", func(t *testing.T) {
+		r := &testZeroFieldRequestMultipartBody{}
 		defer func() {
 			if rec := recover(); rec == nil {
 				t.Errorf("multipart_body: expects Panic, got nil")

--- a/runtime/request_test.go
+++ b/runtime/request_test.go
@@ -84,7 +84,7 @@ func TestJSONBody(t *testing.T) {
 				t.Errorf("json_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "use the value type of a struct rather than a pointer type as the value for generics" {
-				t.Errorf("json_body: unexpected Panic literal => %s", rec)
+				t.Errorf("json_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
@@ -98,7 +98,7 @@ func TestJSONBody(t *testing.T) {
 				t.Errorf("json_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "JSONBody is not the first embedded field of struct type T" {
-				t.Errorf("json_body: unexpected Panic literal => %s", rec)
+				t.Errorf("json_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
@@ -112,11 +112,24 @@ func TestJSONBody(t *testing.T) {
 				t.Errorf("json_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "JSONBody is not the first embedded field of struct type T" {
-				t.Errorf("json_body: unexpected Panic literal => %s", rec)
+				t.Errorf("json_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
 		_, _ = io.ReadAll(r)
+	})
+	t.Run("interface_type_panic", func(t *testing.T) {
+		var b JSONBody[io.Reader]
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Errorf("json_body: expects Panic, got nil")
+				return
+			} else if lit, ok := rec.(string); !ok || lit != "use the value type of a struct rather than a pointer type as the value for generics" {
+				t.Errorf("json_body: unexpected Panic literal => %v", rec)
+				return
+			}
+		}()
+		_, _ = b.Read(nil)
 	})
 }
 
@@ -202,7 +215,7 @@ func TestMultipartBody(t *testing.T) {
 				t.Errorf("multipart_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "use the value type of a struct rather than a pointer type as the value for generics" {
-				t.Errorf("multipart_body: unexpected Panic literal => %s", rec)
+				t.Errorf("multipart_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
@@ -215,7 +228,7 @@ func TestMultipartBody(t *testing.T) {
 				t.Errorf("multipart_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "MultipartBody is not the first embedded field of struct type T" {
-				t.Errorf("multipart_body: unexpected Panic literal => %s", rec)
+				t.Errorf("multipart_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
@@ -228,11 +241,24 @@ func TestMultipartBody(t *testing.T) {
 				t.Errorf("multipart_body: expects Panic, got nil")
 				return
 			} else if lit, ok := rec.(string); !ok || lit != "MultipartBody is not the first embedded field of struct type T" {
-				t.Errorf("multipart_body: unexpected Panic literal => %s", rec)
+				t.Errorf("multipart_body: unexpected Panic literal => %v", rec)
 				return
 			}
 		}()
 		_, _ = io.ReadAll(r)
+	})
+	t.Run("interface_type_panic", func(t *testing.T) {
+		var b MultipartBody[io.Reader]
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Errorf("multipart_body: expects Panic, got nil")
+				return
+			} else if lit, ok := rec.(string); !ok || lit != "use the value type of a struct rather than a pointer type as the value for generics" {
+				t.Errorf("multipart_body: unexpected Panic literal => %v", rec)
+				return
+			}
+		}()
+		_, _ = b.Read(nil)
 	})
 }
 

--- a/test.sh
+++ b/test.sh
@@ -5,5 +5,6 @@ set -x
 
 go test -cover ./gen
 go test -cover ./runtime
+go test -gcflags=all=-d=checkptr=1 ./runtime/...
 go test -cover ./sqlx
 go test -tags=test ./gen/integration


### PR DESCRIPTION
Both JSONBody[T].Read and MultipartBody[T].Read performed
x = *(*T)(unsafe.Pointer(b)) and only afterwards verified the
first-embedded-field invariant. When a caller violated the layout
(e.g. a non-empty field preceded the embedded body), the cast read
past the allocation boundary of b: under -race or
-gcflags=all=-d=checkptr=1 this fired an unrecoverable checkptr
fatal ("converted pointer straddles multiple allocations"); without
checkptr it silently read adjacent memory.

Both sites now compute reflect.TypeOf(x), assert Kind() == Struct,
and assert NumField()>0 && Field(0).Anonymous &&
Field(0).Type == reflect.TypeOf(b).Elem() *before* the unsafe cast.
Existing panic literals are preserved verbatim so existing tests
continue to assert on the friendly messages. A zero-field generic
regression variant trips the "…is not the first embedded field of
struct type T" panic instead of faulting on checkptr.

test.sh gains `go test -gcflags=all=-d=checkptr=1 ./runtime/...`
so contributors running test.sh without -race still trip any
regression of this class.

## Verification

- `go build ./...` ✅ (excluding pre-existing `gen/integration/rpc`)
- `go test ./runtime/...` ✅
- `go test -gcflags=all=-d=checkptr=1 ./runtime/...` ✅

Part of the v1.45.0 security release series; supersedes #10.
