### PR TITLE
🔒 security(sqlx): sandbox #INCLUDE / #SCRIPT header directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### 🔒 Security — generate-time RCE via sqlx #SCRIPT / arbitrary read via #INCLUDE
+
+sqlx `#INCLUDE` anchors to the schema dir / `--include-root`, rejects
+symlinks and `..` escapes, enforces 1 MiB per-file and 4 MiB
+aggregate caps. `#SCRIPT` is disabled by default; opt in with
+`--allow-script` (plus `--script-timeout`, `--script-env`) and it
+runs with a scrubbed env, bounded timeout, and stderr cap.
+`#SCRIPT` is deprecated and slated for removal in v1.47.0.

--- a/README.md
+++ b/README.md
@@ -343,39 +343,78 @@ The `ResponseHandler()` method must return a type that implements the Response i
 
 ### SQL File Inclusion
 
-The `sqlx` mode supports including external SQL files and script output using special directives:
+The `sqlx` mode supports including external SQL files and (optionally) script
+output using special directives.
+
+> ⚠️ **Security**: `#INCLUDE` and `#SCRIPT` execute at **code-generation time**,
+> with the developer's full filesystem and PATH. Treat schema `.go` files as
+> trusted build inputs — never run `defc generate` on an untrusted schema
+> file. See [SECURITY.md](./SECURITY.md) for the full trust model.
 
 #### #INCLUDE Directive
 
-Include external SQL files or use glob patterns:
+Include external SQL files or use glob patterns. For safety, `#INCLUDE`
+paths are constrained to:
+
+- **Schema directory**: relative paths resolve against the directory that
+  contains the schema `.go` file. Paths that escape via `..` are rejected.
+- **`--include-root=DIR`** (repeatable): absolute paths must live under one
+  of the configured roots. Without any `--include-root` flag, absolute
+  paths are rejected.
+- **No symlinks**: any symlink component along the resolved path is
+  rejected.
+- **Size caps**: each matched file ≤ 1 MiB; total material included per
+  directive ≤ 4 MiB.
 
 ```go
 //go:generate go run -mod=mod "github.com/x5iu/defc" --mode=sqlx --output=user_query.go
 type UserQuery interface {
 // GetUser QUERY ONE
-// #INCLUDE "queries/get_user.sql"
+// #INCLUDE "queries/get_user.sql"        // ✅ relative, under schema dir
 GetUser(ctx context.Context, id int64) (*User, error)
 
 // GetActiveUsers QUERY MANY
-// #INCLUDE "queries/*.sql"  // Include all SQL files
+// #INCLUDE "queries/*.sql"                // ✅ glob, sorted deterministically
 GetActiveUsers(ctx context.Context) ([]*User, error)
 }
+
+// Rejected examples:
+//   #INCLUDE "/etc/passwd"                 // absolute, no --include-root
+//   #INCLUDE "../../outside.sql"           // escapes schema directory
+//   #INCLUDE "link.sql"                    // resolves through a symlink
 ```
 
-#### #SCRIPT Directive
+#### #SCRIPT Directive  *(deprecated, off by default)*
 
-Execute shell commands and include their output:
+> ⚠️ **Deprecated.** `#SCRIPT` executes arbitrary commands at generate
+> time. It is **disabled by default** and will be removed in a future
+> release. Prefer checking the rendered SQL into source and including it
+> with `#INCLUDE`.
+
+To keep using `#SCRIPT` during migration, pass `--allow-script` together
+with `--script-timeout` and, when required, `--script-env=NAME`
+(repeatable) to whitelist specific environment variables. The child
+process runs with a scrubbed environment that only inherits
+`PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TMPDIR`,
+`GOCACHE`, `GOMODCACHE`, `GOPATH` plus the names listed via
+`--script-env`. `--script-timeout` is capped at 10 minutes.
 
 ```go
 type UserQuery interface {
 // ListUsers QUERY MANY
 // #SCRIPT cat "queries/list_users.sql"
 ListUsers(ctx context.Context) ([]*User, error)
-
-// GetUserCount QUERY ONE
-// #SCRIPT echo "SELECT COUNT(*) as count FROM users"
-GetUserCount(ctx context.Context) (int64, error)
 }
+```
+
+**Migration:** replace the `#SCRIPT` body with the committed SQL file it
+produces, and use `#INCLUDE` instead:
+
+```go
+// Before:
+// #SCRIPT cat "queries/list_users.sql"
+// After:
+// #INCLUDE "queries/list_users.sql"
 ```
 
 ### Template Debugging

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# Security Policy
+
+## Trust boundary
+
+`defc` is a **code-generation tool** executed by the developer (or by CI on
+behalf of the developer) with the full privileges of that user. Its inputs —
+the schema `.go` files it scans, any files referenced via `#INCLUDE`, and the
+command lines executed via `#SCRIPT` — are trusted build inputs, not
+untrusted user data.
+
+**Do not run `defc generate` on schema files from untrusted sources**
+(e.g. an attacker-controlled pull request merged and then `go generate`-d on
+a developer laptop or in CI). Review `//go:generate` lines and any
+`#INCLUDE` / `#SCRIPT` directives in a schema file the same way you would
+review a shell script before invoking the generator.
+
+## `#INCLUDE` — filesystem boundary
+
+Since v1.45.0, `#INCLUDE` in `sqlx`-mode headers is constrained at
+generate time:
+
+- Relative paths resolve against the directory of the schema `.go` file.
+- Absolute paths are rejected unless they resolve under a configured
+  `--include-root=DIR`.
+- `..` escapes out of the schema directory (and out of any
+  `--include-root`) are rejected.
+- Any symlink component in the resolved path is rejected
+  (`lstat`-based walk from the anchor to the target).
+- Per-file cap: 1 MiB. Aggregate cap per directive: 4 MiB.
+- Glob expansion results are sorted deterministically.
+
+Error messages include the originating `file:line` for diagnostics.
+
+## `#SCRIPT` — deprecated
+
+`#SCRIPT` runs an arbitrary command at code-generation time. As of
+v1.45.0 it is:
+
+- **Disabled by default.** Invocation without `--allow-script` fails with
+  `#SCRIPT is disabled by default; re-run with --allow-script …`.
+- **Sandboxed** when enabled: the child process runs with a scrubbed
+  environment whose baseline is `PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`,
+  `LC_CTYPE`, `TMPDIR`, `GOCACHE`, `GOMODCACHE`, `GOPATH`. Additional
+  variables can be allow-listed one at a time via repeatable
+  `--script-env=NAME` (names must match `^[A-Z_][A-Z0-9_]*$`).
+- **Time-bounded** via `--script-timeout` (e.g. `30s`), capped at
+  10 minutes.
+- **Stderr-bounded**: at most 64 KiB of the child's stderr is captured on
+  failure; the remainder is truncated with a marker.
+- **Logged** on success with a deprecation notice to the generator's
+  stderr.
+
+### Deprecation timeline
+
+- **v1.45.0**: `#SCRIPT` disabled by default, gated behind
+  `--allow-script`, scrubbed env, bounded timeout, deprecation warning.
+- **v1.46.x**: documentation-only reminders; migration tooling stable.
+- **v1.47.0** (planned): `#SCRIPT` is removed. `#INCLUDE` remains as the
+  supported mechanism for pulling external SQL into a header.
+
+### Migration
+
+Commit the rendered SQL produced by the `#SCRIPT` body into the
+repository and reference it from `#INCLUDE` instead:
+
+```go
+// Before:
+// #SCRIPT cat queries/list_users.sql
+// After:
+// #INCLUDE "queries/list_users.sql"
+```
+
+## `splitArgs` is not a shell
+
+The directive argument parser (`splitArgs` consumed by `#INCLUDE`, `#SCRIPT`,
+etc.) supports `${…}` as a **grouping** construct for readability; it is
+**not** shell parameter expansion. It does not expand environment
+variables, does not perform command substitution, and does not invoke a
+shell. Anything that looks like `${PATH}` inside a method option is a
+literal token boundary, not a variable reference.
+
+## Supported versions
+
+Only the latest minor release line receives security fixes. Users on
+older lines should upgrade before reporting issues.
+
+| Version  | Status                   |
+|----------|--------------------------|
+| 1.45.x   | ✅ Supported             |
+| < 1.45.0 | ⚠️ Upgrade recommended   |
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities **privately** via GitHub Security
+Advisories on the `x5iu/defc` repository
+(`Security` → `Report a vulnerability`). Do not file a public issue for
+security problems. We aim to acknowledge reports within 5 business days
+and will coordinate a fix and disclosure window with the reporter.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,8 @@ generate time:
 
 Error messages include the originating `file:line` for diagnostics.
 
+The `#INCLUDE`/`#SCRIPT` sandbox is designed for Unix-like hosts (macOS/Linux); Windows is not a supported target for these directives.
+
 ## `#SCRIPT` — deprecated
 
 `#SCRIPT` runs an arbitrary command at code-generation time. As of

--- a/gen/builder.go
+++ b/gen/builder.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"go/ast"
 	"io"
+	"time"
 )
 
 type Mode int
@@ -87,6 +88,19 @@ type CliBuilder struct {
 
 	// template
 	template string
+
+	// allowScript gates the sqlx-mode `#SCRIPT` directive.
+	allowScript bool
+
+	// scriptTimeout caps each `#SCRIPT` invocation.
+	scriptTimeout time.Duration
+
+	// scriptEnv is an extra names-only env allow-list for `#SCRIPT`.
+	scriptEnv []string
+
+	// includeRoots is an optional list of extra filesystem roots under
+	// which sqlx-mode `#INCLUDE` paths may resolve.
+	includeRoots []string
 }
 
 func (builder *CliBuilder) WithFeats(feats []string) *CliBuilder {
@@ -127,6 +141,26 @@ func (builder *CliBuilder) WithPos(pos int) *CliBuilder {
 
 func (builder *CliBuilder) WithTemplate(template string) *CliBuilder {
 	builder.template = template
+	return builder
+}
+
+func (builder *CliBuilder) WithAllowScript(allow bool) *CliBuilder {
+	builder.allowScript = allow
+	return builder
+}
+
+func (builder *CliBuilder) WithScriptTimeout(timeout time.Duration) *CliBuilder {
+	builder.scriptTimeout = timeout
+	return builder
+}
+
+func (builder *CliBuilder) WithScriptEnv(env []string) *CliBuilder {
+	builder.scriptEnv = env
+	return builder
+}
+
+func (builder *CliBuilder) WithIncludeRoots(roots []string) *CliBuilder {
+	builder.includeRoots = roots
 	return builder
 }
 

--- a/gen/method.go
+++ b/gen/method.go
@@ -62,6 +62,9 @@ func (method *Method) SortIn() []string {
 var backslashRe = regexp.MustCompile(`\\[ \t\r]*?\n[ \t\r]*`)
 
 func (method *Method) MetaArgs() []string {
+	// NOTE: splitArgs is a custom, NON-shell tokeniser. `${...}` here is a
+	// grouping delimiter identical to `$(...)`, not a POSIX variable
+	// expansion. See SECURITY.md (`splitArgs` non-shell note).
 	rawArgs := splitArgs(backslashRe.ReplaceAllString(method.Meta, ""))
 	args := make([]string, 0, len(rawArgs))
 	for i := 0; i < len(rawArgs); i++ {

--- a/gen/sqlx.go
+++ b/gen/sqlx.go
@@ -389,7 +389,7 @@ func isPathUnder(child, parent string) bool {
 	if rel == "." {
 		return true
 	}
-	if strings.HasPrefix(rel, "..") {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return false
 	}
 	return !filepath.IsAbs(rel)

--- a/gen/sqlx.go
+++ b/gen/sqlx.go
@@ -3,13 +3,18 @@ package gen
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	_ "embed"
 )
@@ -20,6 +25,13 @@ const (
 
 	sqlxMethodWithTx = "WithTx"
 
+	// sqlxCmdInclude expands to the contents of one or more files under the
+	// schema directory (or a configured --include-root). Symlinks are
+	// rejected and per-file / aggregate size caps apply. See SECURITY.md.
+	//
+	// sqlxCmdScript executes an external command at generate time. It is
+	// gated behind --allow-script and is DEPRECATED for removal in the next
+	// minor release; see SECURITY.md for the migration path.
 	sqlxCmdInclude = "#INCLUDE"
 	sqlxCmdScript  = "#SCRIPT"
 
@@ -54,6 +66,7 @@ type sqlxContext struct {
 	Imports         []string
 	Funcs           []string
 	Pwd             string
+	HeaderCfg       *readHeaderConfig
 	Doc             Doc
 	Template        string
 }
@@ -305,6 +318,24 @@ inspectType:
 		}
 	}
 
+	schemaDir := builder.pwd
+	if builder.file != "" {
+		if abs := builder.file; filepath.IsAbs(abs) {
+			schemaDir = filepath.Dir(abs)
+		} else {
+			schemaDir = filepath.Dir(filepath.Join(builder.pwd, abs))
+		}
+	}
+	headerCfg := &readHeaderConfig{
+		schemaDir:     schemaDir,
+		includeRoots:  append([]string(nil), builder.includeRoots...),
+		allowScript:   builder.allowScript,
+		scriptTimeout: builder.scriptTimeout,
+		scriptEnv:     append([]string(nil), builder.scriptEnv...),
+		directiveFile: builder.file,
+		lineOffset:    builder.pos,
+	}
+
 	return &sqlxContext{
 		Package:   builder.pkg,
 		BuildTags: parseBuildTags(builder.doc),
@@ -314,76 +345,248 @@ inspectType:
 		Features:  sqlxFeatures,
 		Imports:   builder.imports,
 		Funcs:     builder.funcs,
+		Pwd:       builder.pwd,
+		HeaderCfg: headerCfg,
 		Doc:       builder.doc,
 		Template:  builder.template,
 	}, nil
 }
 
-func readHeader(header string, pwd string) (string, error) {
-	var buf bytes.Buffer
-	scanner := bufio.NewScanner(strings.NewReader(header))
-	var text string
+// readHeaderConfig carries the policy knobs readHeader needs to evaluate
+// `#INCLUDE` / `#SCRIPT` directives safely. Anchors `#INCLUDE` to the schema
+// file's own directory plus any caller-supplied includeRoots; gates `#SCRIPT`
+// behind allowScript; bounds `#SCRIPT` execution via scriptTimeout; scrubs
+// the child env down to scriptEnv plus the runCommand baseline allow-list;
+// and carries directiveFile / lineOffset so diagnostics can report `file:line`
+// pointing at the offending directive.
+type readHeaderConfig struct {
+	schemaDir     string
+	includeRoots  []string
+	allowScript   bool
+	scriptTimeout time.Duration
+	scriptEnv     []string
+	directiveFile string
+	lineOffset    int
+}
+
+const (
+	includePerFileCap   = 1 * 1024 * 1024 // 1 MiB
+	includeAggregateCap = 4 * 1024 * 1024 // 4 MiB
+)
+
+// isPathUnder reports whether child, after cleaning, is lexically equal to or
+// a descendant of parent (also cleaned). Both arguments must be absolute.
+func isPathUnder(child, parent string) bool {
+	c := filepath.Clean(child)
+	p := filepath.Clean(parent)
+	if c == p {
+		return true
+	}
+	rel, err := filepath.Rel(p, c)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if strings.HasPrefix(rel, "..") {
+		return false
+	}
+	return !filepath.IsAbs(rel)
+}
+
+// rejectSymlinkInPath walks every component from `anchor` (inclusive) down to
+// `target` (inclusive) and reports an error if any is a symlink. Both inputs
+// must be clean absolute paths; `target` must lie under `anchor`.
+func rejectSymlinkInPath(anchor, target string) error {
+	anchor = filepath.Clean(anchor)
+	target = filepath.Clean(target)
+	rel, err := filepath.Rel(anchor, target)
+	if err != nil {
+		return err
+	}
+	current := anchor
+	// Check the anchor itself.
+	if fi, err := lstat(current); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink not allowed at %q", current)
+		}
+	}
+	if rel == "." {
+		return nil
+	}
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		fi, err := lstat(current)
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink not allowed at %q", current)
+		}
+	}
+	return nil
+}
+
+// resolveIncludePath anchors a user-supplied #INCLUDE path (which may be a
+// glob pattern) to the schema directory or one of the explicit include roots,
+// rejecting anything that escapes. The returned path is a clean absolute
+// pattern suitable for filepath.Glob; the returned anchor is the root the
+// pattern resolved under (used for per-component symlink rejection).
+func resolveIncludePath(rawPath string, cfg *readHeaderConfig) (pattern, anchor string, err error) {
+	var resolved string
+	if filepath.IsAbs(rawPath) {
+		resolved = filepath.Clean(rawPath)
+		for _, root := range cfg.includeRoots {
+			if isPathUnder(resolved, root) {
+				return resolved, filepath.Clean(root), nil
+			}
+		}
+		return "", "", fmt.Errorf("uses an absolute path that does not lie under any --include-root")
+	}
+	resolved = filepath.Clean(filepath.Join(cfg.schemaDir, rawPath))
+	if isPathUnder(resolved, cfg.schemaDir) {
+		return resolved, filepath.Clean(cfg.schemaDir), nil
+	}
+	for _, root := range cfg.includeRoots {
+		if isPathUnder(resolved, root) {
+			return resolved, filepath.Clean(root), nil
+		}
+	}
+	return "", "", fmt.Errorf("resolves to %q which is outside the schema directory and all --include-root entries", resolved)
+}
+
+func readHeader(header string, cfg *readHeaderConfig) (string, error) {
+	if cfg == nil {
+		cfg = &readHeaderConfig{}
+	}
+	var (
+		buf           bytes.Buffer
+		scanner       = bufio.NewScanner(strings.NewReader(header))
+		text          string
+		lineNo        int // 1-based line within `header`
+		currentLineNo int // line on which the current directive began
+		includedTotal int64
+	)
+
 	for {
 		if text == "" {
 			if !scanner.Scan() {
 				break
 			}
+			lineNo++
 			text = scanner.Text()
+			currentLineNo = lineNo
 		}
 
-		var next string
+		var (
+			next       string
+			nextLineNo int
+			haveNext   bool
+		)
 		for {
 			if !scanner.Scan() {
 				break
 			}
-			next = scanner.Text()
-			if len(next) > 0 && (next[0] == ' ' || next[0] == '\t') {
-				text += " " + trimSpace(next)
-				next = "" // next is consumed here
+			lineNo++
+			candidate := scanner.Text()
+			if len(candidate) > 0 && (candidate[0] == ' ' || candidate[0] == '\t') {
+				text += " " + trimSpace(candidate)
 			} else {
+				next = candidate
+				nextLineNo = lineNo
+				haveNext = true
 				break
 			}
 		}
 
 		text = trimSpace(text)
 		args := splitArgs(text)
+		directiveLine := cfg.lineOffset + currentLineNo
 
-		// parse #include/#script command which should be placed in a new line
 		if len(args) == 2 && toUpper(args[0]) == sqlxCmdInclude {
-			// unquote path pattern if it is quoted
-			path := unquote(args[1])
-			if !isAbs(path) {
-				path = join(pwd, path)
+			rawPath := unquote(args[1])
+			pattern, anchor, resolveErr := resolveIncludePath(rawPath, cfg)
+			if resolveErr != nil {
+				return "", fmt.Errorf("#INCLUDE %q at %s:%d %s",
+					rawPath, cfg.directiveFile, directiveLine, resolveErr.Error())
 			}
-			// get filenames that match the pattern
-			matches, err := glob(path)
+			matches, err := glob(pattern)
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("#INCLUDE %q at %s:%d: filepath.Glob(%q): %w",
+					rawPath, cfg.directiveFile, directiveLine, pattern, err)
 			}
-			// read each file into buffer
-			for _, path = range matches {
-				if !isAbs(path) {
-					path = join(pwd, path)
+			if len(matches) == 0 {
+				return "", fmt.Errorf("#INCLUDE %q at %s:%d matched no files",
+					rawPath, cfg.directiveFile, directiveLine)
+			}
+			sort.Strings(matches)
+			for _, match := range matches {
+				if !filepath.IsAbs(match) {
+					match = filepath.Clean(filepath.Join(cfg.schemaDir, match))
+				} else {
+					match = filepath.Clean(match)
 				}
-				content, err := read(path)
+				if err := rejectSymlinkInPath(anchor, match); err != nil {
+					return "", fmt.Errorf("#INCLUDE %q at %s:%d: %s",
+						rawPath, cfg.directiveFile, directiveLine, err.Error())
+				}
+				fi, err := stat(match)
 				if err != nil {
-					return "", fmt.Errorf("os.ReadFile(%s): %w", quote(path), err)
+					return "", fmt.Errorf("#INCLUDE %q at %s:%d: os.Stat(%q): %w",
+						rawPath, cfg.directiveFile, directiveLine, match, err)
 				}
-				buf.WriteString(string(content))
+				if fi.IsDir() {
+					continue
+				}
+				if fi.Size() > includePerFileCap {
+					return "", fmt.Errorf("#INCLUDE %q at %s:%d: file %q exceeds 1 MiB per-file limit (%d bytes)",
+						rawPath, cfg.directiveFile, directiveLine, match, fi.Size())
+				}
+				if includedTotal+fi.Size() > includeAggregateCap {
+					return "", fmt.Errorf("#INCLUDE %q at %s:%d: total included bytes exceed 4 MiB aggregate limit",
+						rawPath, cfg.directiveFile, directiveLine)
+				}
+				content, err := read(match)
+				if err != nil {
+					return "", fmt.Errorf("#INCLUDE %q at %s:%d: os.ReadFile(%q): %w",
+						rawPath, cfg.directiveFile, directiveLine, match, err)
+				}
+				includedTotal += int64(len(content))
+				buf.Write(content)
 			}
 		} else if len(args) > 1 && toUpper(args[0]) == sqlxCmdScript {
-			output, err := runCommand(args[1:])
-			if err != nil {
-				return "", err
+			if !cfg.allowScript {
+				return "", fmt.Errorf("#SCRIPT directive at %s:%d is disabled by default; re-run with --allow-script if you understand the security implications (see SECURITY.md)",
+					cfg.directiveFile, directiveLine)
 			}
+			timeout := cfg.scriptTimeout
+			if timeout <= 0 {
+				timeout = 10 * time.Second
+			}
+			output, err := runCommand(context.Background(), args[1:], timeout, cfg.scriptEnv)
+			if err != nil {
+				return "", fmt.Errorf("#SCRIPT at %s:%d: %w",
+					cfg.directiveFile, directiveLine, err)
+			}
+			fmt.Fprintf(os.Stderr, "defc: warning: #SCRIPT at %s:%d is deprecated and will be removed in a future release; see SECURITY.md\n",
+				cfg.directiveFile, directiveLine)
 			buf.WriteString(output)
 		} else {
 			buf.WriteString(text)
 		}
 		buf.WriteString("\r\n")
 
-		// now next becomes the current line
-		text = next
+		if haveNext {
+			text = next
+			currentLineNo = nextLineNo
+		} else {
+			text = ""
+			break
+		}
 	}
 	return buf.String(), nil
 }
@@ -410,14 +613,14 @@ func (ctx *sqlxContext) genSqlxCode(w io.Writer) error {
 			"isPointer":     isPointer,
 			"indirect":      indirect,
 			"deselect":      deselect,
-			"readHeader":    func(header string) (string, error) { return readHeader(header, ctx.Pwd) },
+			"readHeader":    func(header string) (string, error) { return readHeader(header, ctx.HeaderCfg) },
 			"isContextType": func(ident string, expr ast.Expr) bool { return ctx.Doc.IsContextType(ident, expr) },
 			"sub":           func(x, y int) int { return x - y },
 			"getRepr":       func(node ast.Node) string { return ctx.Doc.Repr(node) },
 			"isQuery":       func(op string) bool { return op == sqlxOpQuery },
 			"isExec":        func(op string) bool { return op == sqlxOpExec },
 			"constBindSQL": func(header string) (string, error) {
-				processed, err := readHeader(header, ctx.Pwd)
+				processed, err := readHeader(header, ctx.HeaderCfg)
 				if err != nil {
 					return "", err
 				}
@@ -428,7 +631,7 @@ func (ctx *sqlxContext) genSqlxCode(w io.Writer) error {
 				return result.SQL, nil
 			},
 			"constBindArgs": func(header string) ([]string, error) {
-				processed, err := readHeader(header, ctx.Pwd)
+				processed, err := readHeader(header, ctx.HeaderCfg)
 				if err != nil {
 					return nil, err
 				}

--- a/gen/sqlx_test.go
+++ b/gen/sqlx_test.go
@@ -230,169 +230,198 @@ func TestBuildSqlx(t *testing.T) {
 // symlinks) are rejected; per-file and aggregate size caps are enforced;
 // well-formed inputs under the schema directory succeed with stable content.
 func TestReadHeader_IncludeBoundary(t *testing.T) {
-schemaDir := t.TempDir()
-if err := os.WriteFile(filepath.Join(schemaDir, "ok.sql"), []byte("SELECT 1;\n"), 0644); err != nil {
-t.Fatal(err)
-}
+	schemaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(schemaDir, "ok.sql"), []byte("SELECT 1;\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-base := func() *readHeaderConfig {
-return &readHeaderConfig{
-schemaDir:     schemaDir,
-directiveFile: filepath.Join(schemaDir, "schema.go"),
-lineOffset:    0,
-}
-}
+	base := func() *readHeaderConfig {
+		return &readHeaderConfig{
+			schemaDir:     schemaDir,
+			directiveFile: filepath.Join(schemaDir, "schema.go"),
+			lineOffset:    0,
+		}
+	}
 
-t.Run("absolute_outside_root", func(t *testing.T) {
-_, err := readHeader(`#INCLUDE "/etc/passwd"`, base())
-if err == nil || !strings.Contains(err.Error(), "absolute path") {
-t.Fatalf("expected absolute-path rejection, got %v", err)
-}
-})
+	t.Run("absolute_outside_root", func(t *testing.T) {
+		_, err := readHeader(`#INCLUDE "/etc/passwd"`, base())
+		if err == nil || !strings.Contains(err.Error(), "absolute path") {
+			t.Fatalf("expected absolute-path rejection, got %v", err)
+		}
+	})
 
-t.Run("relative_escapes_schemadir", func(t *testing.T) {
-_, err := readHeader(`#INCLUDE "../../outside.sql"`, base())
-if err == nil || !strings.Contains(err.Error(), "outside the schema directory") {
-t.Fatalf("expected escape rejection, got %v", err)
-}
-})
+	t.Run("relative_escapes_schemadir", func(t *testing.T) {
+		_, err := readHeader(`#INCLUDE "../../outside.sql"`, base())
+		if err == nil || !strings.Contains(err.Error(), "outside the schema directory") {
+			t.Fatalf("expected escape rejection, got %v", err)
+		}
+	})
 
-t.Run("symlink_rejected", func(t *testing.T) {
-real := filepath.Join(schemaDir, "real.sql")
-if err := os.WriteFile(real, []byte("SELECT 2;\n"), 0644); err != nil {
-t.Fatal(err)
-}
-link := filepath.Join(schemaDir, "link.sql")
-if err := os.Symlink(real, link); err != nil {
-t.Skipf("symlink unsupported: %s", err)
-}
-_, err := readHeader(`#INCLUDE "link.sql"`, base())
-if err == nil || !strings.Contains(err.Error(), "symlink not allowed") {
-t.Fatalf("expected symlink rejection, got %v", err)
-}
-})
+	t.Run("symlink_rejected", func(t *testing.T) {
+		real := filepath.Join(schemaDir, "real.sql")
+		if err := os.WriteFile(real, []byte("SELECT 2;\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(schemaDir, "link.sql")
+		if err := os.Symlink(real, link); err != nil {
+			t.Skipf("symlink unsupported: %s", err)
+		}
+		_, err := readHeader(`#INCLUDE "link.sql"`, base())
+		if err == nil || !strings.Contains(err.Error(), "symlink not allowed") {
+			t.Fatalf("expected symlink rejection, got %v", err)
+		}
+	})
 
-t.Run("per_file_cap", func(t *testing.T) {
-big := filepath.Join(schemaDir, "big.sql")
-if err := os.WriteFile(big, bytes.Repeat([]byte("a"), 1024*1024+1), 0644); err != nil {
-t.Fatal(err)
-}
-defer os.Remove(big)
-_, err := readHeader(`#INCLUDE "big.sql"`, base())
-if err == nil || !strings.Contains(err.Error(), "1 MiB per-file limit") {
-t.Fatalf("expected per-file cap rejection, got %v", err)
-}
-})
+	t.Run("per_file_cap", func(t *testing.T) {
+		big := filepath.Join(schemaDir, "big.sql")
+		if err := os.WriteFile(big, bytes.Repeat([]byte("a"), 1024*1024+1), 0644); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(big)
+		_, err := readHeader(`#INCLUDE "big.sql"`, base())
+		if err == nil || !strings.Contains(err.Error(), "1 MiB per-file limit") {
+			t.Fatalf("expected per-file cap rejection, got %v", err)
+		}
+	})
 
-t.Run("aggregate_cap", func(t *testing.T) {
-aggDir := t.TempDir()
-cfg := &readHeaderConfig{
-schemaDir:     aggDir,
-directiveFile: filepath.Join(aggDir, "schema.go"),
-}
-// Five ~900 KiB files; 4 MiB cap → 5th must trip.
-chunk := bytes.Repeat([]byte("b"), 900*1024)
-for i := 0; i < 5; i++ {
-name := filepath.Join(aggDir, fmt.Sprintf("f%02d.sql", i))
-if err := os.WriteFile(name, chunk, 0644); err != nil {
-t.Fatal(err)
-}
-}
-_, err := readHeader(`#INCLUDE "*.sql"`, cfg)
-if err == nil || !strings.Contains(err.Error(), "4 MiB aggregate limit") {
-t.Fatalf("expected aggregate cap rejection, got %v", err)
-}
-})
+	t.Run("aggregate_cap", func(t *testing.T) {
+		aggDir := t.TempDir()
+		cfg := &readHeaderConfig{
+			schemaDir:     aggDir,
+			directiveFile: filepath.Join(aggDir, "schema.go"),
+		}
+		// Five ~900 KiB files; 4 MiB cap → 5th must trip.
+		chunk := bytes.Repeat([]byte("b"), 900*1024)
+		for i := 0; i < 5; i++ {
+			name := filepath.Join(aggDir, fmt.Sprintf("f%02d.sql", i))
+			if err := os.WriteFile(name, chunk, 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		_, err := readHeader(`#INCLUDE "*.sql"`, cfg)
+		if err == nil || !strings.Contains(err.Error(), "4 MiB aggregate limit") {
+			t.Fatalf("expected aggregate cap rejection, got %v", err)
+		}
+	})
 
-t.Run("happy_path", func(t *testing.T) {
-out, err := readHeader(`#INCLUDE "ok.sql"`, base())
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if !strings.Contains(out, "SELECT 1;") {
-t.Fatalf("expected SELECT 1 in output, got %q", out)
-}
-})
+	t.Run("happy_path", func(t *testing.T) {
+		out, err := readHeader(`#INCLUDE "ok.sql"`, base())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(out, "SELECT 1;") {
+			t.Fatalf("expected SELECT 1 in output, got %q", out)
+		}
+	})
 
-t.Run("no_match", func(t *testing.T) {
-_, err := readHeader(`#INCLUDE "nonexistent.sql"`, base())
-if err == nil || !strings.Contains(err.Error(), "matched no files") {
-t.Fatalf("expected no-match rejection, got %v", err)
-}
-})
+	t.Run("no_match", func(t *testing.T) {
+		_, err := readHeader(`#INCLUDE "nonexistent.sql"`, base())
+		if err == nil || !strings.Contains(err.Error(), "matched no files") {
+			t.Fatalf("expected no-match rejection, got %v", err)
+		}
+	})
 
-t.Run("absolute_under_include_root", func(t *testing.T) {
-rootDir := t.TempDir()
-data := filepath.Join(rootDir, "ext.sql")
-if err := os.WriteFile(data, []byte("SELECT 3;"), 0644); err != nil {
-t.Fatal(err)
-}
-cfg := base()
-cfg.includeRoots = []string{rootDir}
-out, err := readHeader(fmt.Sprintf(`#INCLUDE %q`, data), cfg)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if !strings.Contains(out, "SELECT 3;") {
-t.Fatalf("expected content, got %q", out)
-}
-})
+	t.Run("absolute_under_include_root", func(t *testing.T) {
+		rootDir := t.TempDir()
+		data := filepath.Join(rootDir, "ext.sql")
+		if err := os.WriteFile(data, []byte("SELECT 3;"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		cfg := base()
+		cfg.includeRoots = []string{rootDir}
+		out, err := readHeader(fmt.Sprintf(`#INCLUDE %q`, data), cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(out, "SELECT 3;") {
+			t.Fatalf("expected content, got %q", out)
+		}
+	})
 }
 
 // TestReadHeader_ScriptGating covers the #SCRIPT gating/timeout/env hardening.
 func TestReadHeader_ScriptGating(t *testing.T) {
-schemaDir := t.TempDir()
-baseCfg := func() *readHeaderConfig {
-return &readHeaderConfig{
-schemaDir:     schemaDir,
-directiveFile: filepath.Join(schemaDir, "schema.go"),
-}
+	schemaDir := t.TempDir()
+	baseCfg := func() *readHeaderConfig {
+		return &readHeaderConfig{
+			schemaDir:     schemaDir,
+			directiveFile: filepath.Join(schemaDir, "schema.go"),
+		}
+	}
+
+	t.Run("disabled_by_default", func(t *testing.T) {
+		_, err := readHeader(`#SCRIPT echo hi`, baseCfg())
+		if err == nil || !strings.Contains(err.Error(), "disabled by default") {
+			t.Fatalf("expected gating error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "--allow-script") {
+			t.Fatalf("expected mention of --allow-script, got %v", err)
+		}
+	})
+
+	t.Run("allowed_with_flag", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.allowScript = true
+		cfg.scriptTimeout = 10 * time.Second
+		out, err := readHeader(`#SCRIPT echo hi`, cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(out, "hi") {
+			t.Fatalf("expected 'hi' in output, got %q", out)
+		}
+	})
+
+	t.Run("timeout_trips", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.allowScript = true
+		cfg.scriptTimeout = 100 * time.Millisecond
+		_, err := readHeader(`#SCRIPT sleep 5`, cfg)
+		if err == nil || !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("expected timeout error, got %v", err)
+		}
+	})
+
+	t.Run("env_scrubbed", func(t *testing.T) {
+		t.Setenv("DEFC_TEST_SECRET_HDR", "leaked")
+		cfg := baseCfg()
+		cfg.allowScript = true
+		cfg.scriptTimeout = 10 * time.Second
+		out, err := readHeader(`#SCRIPT env`, cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(out, "DEFC_TEST_SECRET_HDR") {
+			t.Fatalf("expected DEFC_TEST_SECRET_HDR to be absent from scrubbed child env, got:\n%s", out)
+		}
+	})
 }
 
-t.Run("disabled_by_default", func(t *testing.T) {
-_, err := readHeader(`#SCRIPT echo hi`, baseCfg())
-if err == nil || !strings.Contains(err.Error(), "disabled by default") {
-t.Fatalf("expected gating error, got %v", err)
-}
-if !strings.Contains(err.Error(), "--allow-script") {
-t.Fatalf("expected mention of --allow-script, got %v", err)
-}
-})
-
-t.Run("allowed_with_flag", func(t *testing.T) {
-cfg := baseCfg()
-cfg.allowScript = true
-cfg.scriptTimeout = 10 * time.Second
-out, err := readHeader(`#SCRIPT echo hi`, cfg)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if !strings.Contains(out, "hi") {
-t.Fatalf("expected 'hi' in output, got %q", out)
-}
-})
-
-t.Run("timeout_trips", func(t *testing.T) {
-cfg := baseCfg()
-cfg.allowScript = true
-cfg.scriptTimeout = 100 * time.Millisecond
-_, err := readHeader(`#SCRIPT sleep 5`, cfg)
-if err == nil || !strings.Contains(err.Error(), "timeout") {
-t.Fatalf("expected timeout error, got %v", err)
-}
-})
-
-t.Run("env_scrubbed", func(t *testing.T) {
-t.Setenv("DEFC_TEST_SECRET_HDR", "leaked")
-cfg := baseCfg()
-cfg.allowScript = true
-cfg.scriptTimeout = 10 * time.Second
-out, err := readHeader(`#SCRIPT env`, cfg)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if strings.Contains(out, "DEFC_TEST_SECRET_HDR") {
-t.Fatalf("expected DEFC_TEST_SECRET_HDR to be absent from scrubbed child env, got:\n%s", out)
-}
-})
+func TestIsPathUnder(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+		child  string
+		want   bool
+	}{
+		{
+			name:   "segment_starting_with_dotdot_is_not_escape",
+			parent: "/tmp/parent",
+			child:  "/tmp/parent/..foo/bar",
+			want:   true,
+		},
+		{
+			name:   "relative_escape_rejected",
+			parent: "/tmp/parent",
+			child:  "/tmp/escape",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPathUnder(tt.child, tt.parent); got != tt.want {
+				t.Fatalf("isPathUnder(%q, %q) = %v, want %v", tt.child, tt.parent, got, tt.want)
+			}
+		})
+	}
 }

--- a/gen/sqlx_test.go
+++ b/gen/sqlx_test.go
@@ -3,10 +3,12 @@ package gen
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildSqlx(t *testing.T) {
@@ -69,6 +71,8 @@ func TestBuildSqlx(t *testing.T) {
 			WithPwd(testDirAbs).
 			WithFile(testGo, doc).
 			WithPos(pos).
+			WithAllowScript(true).
+			WithScriptTimeout(10 * time.Second).
 			WithTemplate(quote(`{{ define "test_template" }} test_template {{ end }}`)), true
 	}
 	t.Run("success", func(t *testing.T) {
@@ -219,4 +223,176 @@ func TestBuildSqlx(t *testing.T) {
 			return
 		}
 	})
+}
+
+// TestReadHeader_IncludeBoundary covers the #INCLUDE hardening: paths that
+// escape the schema directory (via absolute paths, ".." segments, or
+// symlinks) are rejected; per-file and aggregate size caps are enforced;
+// well-formed inputs under the schema directory succeed with stable content.
+func TestReadHeader_IncludeBoundary(t *testing.T) {
+schemaDir := t.TempDir()
+if err := os.WriteFile(filepath.Join(schemaDir, "ok.sql"), []byte("SELECT 1;\n"), 0644); err != nil {
+t.Fatal(err)
+}
+
+base := func() *readHeaderConfig {
+return &readHeaderConfig{
+schemaDir:     schemaDir,
+directiveFile: filepath.Join(schemaDir, "schema.go"),
+lineOffset:    0,
+}
+}
+
+t.Run("absolute_outside_root", func(t *testing.T) {
+_, err := readHeader(`#INCLUDE "/etc/passwd"`, base())
+if err == nil || !strings.Contains(err.Error(), "absolute path") {
+t.Fatalf("expected absolute-path rejection, got %v", err)
+}
+})
+
+t.Run("relative_escapes_schemadir", func(t *testing.T) {
+_, err := readHeader(`#INCLUDE "../../outside.sql"`, base())
+if err == nil || !strings.Contains(err.Error(), "outside the schema directory") {
+t.Fatalf("expected escape rejection, got %v", err)
+}
+})
+
+t.Run("symlink_rejected", func(t *testing.T) {
+real := filepath.Join(schemaDir, "real.sql")
+if err := os.WriteFile(real, []byte("SELECT 2;\n"), 0644); err != nil {
+t.Fatal(err)
+}
+link := filepath.Join(schemaDir, "link.sql")
+if err := os.Symlink(real, link); err != nil {
+t.Skipf("symlink unsupported: %s", err)
+}
+_, err := readHeader(`#INCLUDE "link.sql"`, base())
+if err == nil || !strings.Contains(err.Error(), "symlink not allowed") {
+t.Fatalf("expected symlink rejection, got %v", err)
+}
+})
+
+t.Run("per_file_cap", func(t *testing.T) {
+big := filepath.Join(schemaDir, "big.sql")
+if err := os.WriteFile(big, bytes.Repeat([]byte("a"), 1024*1024+1), 0644); err != nil {
+t.Fatal(err)
+}
+defer os.Remove(big)
+_, err := readHeader(`#INCLUDE "big.sql"`, base())
+if err == nil || !strings.Contains(err.Error(), "1 MiB per-file limit") {
+t.Fatalf("expected per-file cap rejection, got %v", err)
+}
+})
+
+t.Run("aggregate_cap", func(t *testing.T) {
+aggDir := t.TempDir()
+cfg := &readHeaderConfig{
+schemaDir:     aggDir,
+directiveFile: filepath.Join(aggDir, "schema.go"),
+}
+// Five ~900 KiB files; 4 MiB cap → 5th must trip.
+chunk := bytes.Repeat([]byte("b"), 900*1024)
+for i := 0; i < 5; i++ {
+name := filepath.Join(aggDir, fmt.Sprintf("f%02d.sql", i))
+if err := os.WriteFile(name, chunk, 0644); err != nil {
+t.Fatal(err)
+}
+}
+_, err := readHeader(`#INCLUDE "*.sql"`, cfg)
+if err == nil || !strings.Contains(err.Error(), "4 MiB aggregate limit") {
+t.Fatalf("expected aggregate cap rejection, got %v", err)
+}
+})
+
+t.Run("happy_path", func(t *testing.T) {
+out, err := readHeader(`#INCLUDE "ok.sql"`, base())
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if !strings.Contains(out, "SELECT 1;") {
+t.Fatalf("expected SELECT 1 in output, got %q", out)
+}
+})
+
+t.Run("no_match", func(t *testing.T) {
+_, err := readHeader(`#INCLUDE "nonexistent.sql"`, base())
+if err == nil || !strings.Contains(err.Error(), "matched no files") {
+t.Fatalf("expected no-match rejection, got %v", err)
+}
+})
+
+t.Run("absolute_under_include_root", func(t *testing.T) {
+rootDir := t.TempDir()
+data := filepath.Join(rootDir, "ext.sql")
+if err := os.WriteFile(data, []byte("SELECT 3;"), 0644); err != nil {
+t.Fatal(err)
+}
+cfg := base()
+cfg.includeRoots = []string{rootDir}
+out, err := readHeader(fmt.Sprintf(`#INCLUDE %q`, data), cfg)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if !strings.Contains(out, "SELECT 3;") {
+t.Fatalf("expected content, got %q", out)
+}
+})
+}
+
+// TestReadHeader_ScriptGating covers the #SCRIPT gating/timeout/env hardening.
+func TestReadHeader_ScriptGating(t *testing.T) {
+schemaDir := t.TempDir()
+baseCfg := func() *readHeaderConfig {
+return &readHeaderConfig{
+schemaDir:     schemaDir,
+directiveFile: filepath.Join(schemaDir, "schema.go"),
+}
+}
+
+t.Run("disabled_by_default", func(t *testing.T) {
+_, err := readHeader(`#SCRIPT echo hi`, baseCfg())
+if err == nil || !strings.Contains(err.Error(), "disabled by default") {
+t.Fatalf("expected gating error, got %v", err)
+}
+if !strings.Contains(err.Error(), "--allow-script") {
+t.Fatalf("expected mention of --allow-script, got %v", err)
+}
+})
+
+t.Run("allowed_with_flag", func(t *testing.T) {
+cfg := baseCfg()
+cfg.allowScript = true
+cfg.scriptTimeout = 10 * time.Second
+out, err := readHeader(`#SCRIPT echo hi`, cfg)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if !strings.Contains(out, "hi") {
+t.Fatalf("expected 'hi' in output, got %q", out)
+}
+})
+
+t.Run("timeout_trips", func(t *testing.T) {
+cfg := baseCfg()
+cfg.allowScript = true
+cfg.scriptTimeout = 100 * time.Millisecond
+_, err := readHeader(`#SCRIPT sleep 5`, cfg)
+if err == nil || !strings.Contains(err.Error(), "timeout") {
+t.Fatalf("expected timeout error, got %v", err)
+}
+})
+
+t.Run("env_scrubbed", func(t *testing.T) {
+t.Setenv("DEFC_TEST_SECRET_HDR", "leaked")
+cfg := baseCfg()
+cfg.allowScript = true
+cfg.scriptTimeout = 10 * time.Second
+out, err := readHeader(`#SCRIPT env`, cfg)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if strings.Contains(out, "DEFC_TEST_SECRET_HDR") {
+t.Fatalf("expected DEFC_TEST_SECRET_HDR to be absent from scrubbed child env, got:\n%s", out)
+}
+})
 }

--- a/gen/tools.go
+++ b/gen/tools.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func assert(expr bool, msg string) {
@@ -45,6 +47,8 @@ var (
 	isAbs      = filepath.IsAbs
 	glob       = filepath.Glob
 	read       = os.ReadFile
+	lstat      = os.Lstat
+	stat       = os.Stat
 	list       = os.ReadDir
 )
 
@@ -146,6 +150,12 @@ func fmtNode(node ast.Node) string {
 	return fmt.Sprintf("%#v", node)
 }
 
+// splitArgs tokenises a directive line using a small, custom state machine that
+// understands double-quoted, single-quoted, backquoted, `(…)`-grouped and
+// `{…}`-grouped tokens. The `${…}` form is treated as a grouping delimiter
+// identical to `$(…)` for tokenisation purposes; this is NOT POSIX/bash
+// `${VAR}` expansion. No shell is ever involved — tokens are ultimately
+// handed to `exec.Command` argv directly (by `runCommand`). See SECURITY.md.
 func splitArgs(line string) (args []string) {
 	line = trimSpace(line)
 	if len(line) == 0 {
@@ -316,14 +326,64 @@ func isBackQuoted(s string) bool {
 	return hasPrefix(s, "`") && hasSuffix(s, "`")
 }
 
-func runCommand(args []string) (string, error) {
+// scriptBaselineEnvNames is the always-on names-only allow-list for #SCRIPT
+// invocations. Values are copied from the current process env at runtime.
+var scriptBaselineEnvNames = []string{
+	"PATH", "HOME", "USER",
+	"LANG", "LC_ALL", "LC_CTYPE",
+	"TMPDIR",
+	"GOCACHE", "GOMODCACHE", "GOPATH",
+}
+
+// scriptStderrCap bounds the stderr captured from a #SCRIPT invocation so a
+// runaway child process can't exhaust generator RAM. Anything beyond this is
+// dropped with a trailing truncation marker in the returned error.
+const scriptStderrCap = 64 * 1024
+
+// buildScriptEnv constructs the scrubbed process env for a #SCRIPT invocation:
+// only names listed in the baseline allow-list plus the caller-supplied extra
+// names are passed through, and only when the current process actually has a
+// value set for them.
+func buildScriptEnv(extra []string) []string {
+	seen := make(map[string]struct{}, len(scriptBaselineEnvNames)+len(extra))
+	names := make([]string, 0, len(scriptBaselineEnvNames)+len(extra))
+	for _, n := range scriptBaselineEnvNames {
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		names = append(names, n)
+	}
+	for _, n := range extra {
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		names = append(names, n)
+	}
+	env := make([]string, 0, len(names))
+	for _, n := range names {
+		if v, ok := os.LookupEnv(n); ok {
+			env = append(env, n+"="+v)
+		}
+	}
+	return env
+}
+
+// runCommand executes argv against a scrubbed environment under a bounded
+// timeout. It still recognises `` `…` ``, `$(…)` and `${…}` within its own
+// argv as recursive substitutions (preserved for backwards-compatibility with
+// existing #SCRIPT users; see SECURITY.md for the deprecation timeline).
+// argv[0] must be either a bare command name resolvable via `exec.LookPath`
+// or an absolute path; relative paths are rejected.
+func runCommand(ctx context.Context, args []string, timeout time.Duration, envAllow []string) (string, error) {
 	assert(len(args) > 0, "empty command")
 	repl := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if isBackQuoted(arg) {
 			if innerArgs := splitArgs(unquote(arg)); len(innerArgs) > 0 {
-				innerOutput, err := runCommand(innerArgs)
+				innerOutput, err := runCommand(ctx, innerArgs, timeout, envAllow)
 				if err != nil {
 					return "", err
 				}
@@ -332,7 +392,7 @@ func runCommand(args []string) (string, error) {
 		} else if (hasPrefix(arg, "$(") && hasSuffix(arg, ")")) ||
 			(hasPrefix(arg, "${") && hasSuffix(arg, "}")) {
 			if innerArgs := splitArgs(arg[2 : len(arg)-1]); len(innerArgs) > 0 {
-				innerOutput, err := runCommand(innerArgs)
+				innerOutput, err := runCommand(ctx, innerArgs, timeout, envAllow)
 				if err != nil {
 					return "", err
 				}
@@ -345,14 +405,130 @@ func runCommand(args []string) (string, error) {
 	if len(repl) == 0 {
 		return "", nil
 	}
-	var output bytes.Buffer
-	command := exec.Command(repl[0], repl[1:]...)
+
+	// Build scrubbed env first so PATH lookup uses only the allow-listed PATH.
+	env := buildScriptEnv(envAllow)
+
+	// Resolve argv[0]: absolute path accepted as-is; a path containing a '/'
+	// but not absolute is rejected (prevents ./attacker smuggling); bare names
+	// are resolved via exec.LookPath against the scrubbed PATH.
+	argv0 := repl[0]
+	if !filepath.IsAbs(argv0) {
+		if strings.ContainsRune(argv0, os.PathSeparator) || strings.ContainsRune(argv0, '/') {
+			return "", fmt.Errorf("runCommand: command %q is a relative path; use an absolute path or a bare binary name resolvable via PATH", argv0)
+		}
+		// Manually resolve argv[0] against the scrubbed PATH without mutating
+		// the parent process env (tests and the generator itself run
+		// concurrently with other goroutines that may read PATH).
+		var scrubbedPath string
+		for _, kv := range env {
+			if strings.HasPrefix(kv, "PATH=") {
+				scrubbedPath = kv[len("PATH="):]
+				break
+			}
+		}
+		resolved, lookErr := lookPathIn(argv0, scrubbedPath)
+		if lookErr != nil {
+			return "", fmt.Errorf("runCommand: command %q not found in PATH: %w", argv0, lookErr)
+		}
+		argv0 = resolved
+	}
+
+	// Apply timeout via a derived context. A zero or negative timeout means
+	// "no runCommand-internal timeout" — parent ctx still governs.
+	cmdCtx := ctx
+	if cmdCtx == nil {
+		cmdCtx = context.Background()
+	}
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		cmdCtx, cancel = context.WithTimeout(cmdCtx, timeout)
+		defer cancel()
+	}
+
+	var (
+		output    bytes.Buffer
+		stderrBuf bytes.Buffer
+	)
+	command := exec.CommandContext(cmdCtx, argv0, repl[1:]...)
+	command.Env = env
+	command.Stdin = nil
 	command.Stdout = &output
-	command.Stderr = os.Stderr
+	command.Stderr = &boundedWriter{buf: &stderrBuf, cap: scriptStderrCap}
 	if err := command.Run(); err != nil {
-		return "", err
+		if cmdCtx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("runCommand: command %q exceeded %s timeout", argv0, timeout)
+		}
+		stderrOut := stderrBuf.String()
+		if stderrOut != "" {
+			return "", fmt.Errorf("runCommand: %q exited non-zero: %w\nstderr: %s", argv0, err, stderrOut)
+		}
+		return "", fmt.Errorf("runCommand: %q exited non-zero: %w", argv0, err)
 	}
 	return trimSpace(output.String()), nil
+}
+
+// lookPathIn resolves `name` against the supplied PATH string (colon-separated
+// on Unix, ';'-separated on Windows). Unlike exec.LookPath it does not consult
+// process-wide env, which makes it safe to call concurrently without mutating
+// os.Environ.
+func lookPathIn(name, path string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		// Should have been caught by the absolute-path branch; defensive.
+		if _, err := os.Stat(name); err != nil {
+			return "", err
+		}
+		return name, nil
+	}
+	sep := byte(':')
+	if os.PathSeparator == '\\' {
+		sep = ';'
+	}
+	if path == "" {
+		return "", fmt.Errorf("executable file %q not found in empty PATH", name)
+	}
+	for _, dir := range strings.Split(path, string(sep)) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		fi, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if fi.Mode().IsRegular() && fi.Mode()&0111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("executable file %q not found in PATH", name)
+}
+
+// boundedWriter is an io.Writer that captures at most `cap` bytes, discarding
+// the tail and appending a truncation marker when the limit is exceeded.
+type boundedWriter struct {
+	buf       *bytes.Buffer
+	cap       int
+	truncated bool
+}
+
+func (w *boundedWriter) Write(p []byte) (int, error) {
+	if w.buf.Len() >= w.cap {
+		if !w.truncated {
+			w.buf.WriteString("\n… (truncated)")
+			w.truncated = true
+		}
+		return len(p), nil
+	}
+	remaining := w.cap - w.buf.Len()
+	if remaining >= len(p) {
+		return w.buf.Write(p)
+	}
+	w.buf.Write(p[:remaining])
+	if !w.truncated {
+		w.buf.WriteString("\n… (truncated)")
+		w.truncated = true
+	}
+	return len(p), nil
 }
 
 var ErrNoTargetDeclFound = errors.New("no target decl found")

--- a/gen/tools_test.go
+++ b/gen/tools_test.go
@@ -1,22 +1,27 @@
 package gen
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunCommand(t *testing.T) {
+	ctx := context.Background()
+	const to = 10 * time.Second
 	t.Run("backquoted", func(t *testing.T) {
-		commandOutput, err := runCommand([]string{
+		commandOutput, err := runCommand(ctx, []string{
 			"echo",
 			"`echo test`",
-		})
+		}, to, nil)
 		if err != nil {
 			t.Errorf("runCommand: %s", err)
 			return
@@ -26,10 +31,10 @@ func TestRunCommand(t *testing.T) {
 			return
 		}
 		t.Run("error", func(t *testing.T) {
-			commandOutput, err := runCommand([]string{
+			commandOutput, err := runCommand(ctx, []string{
 				"echo",
 				fmt.Sprintf("`%s/a_binary_name_that_will_never_appear_in_syspath`", t.TempDir()),
-			})
+			}, to, nil)
 			if err == nil || commandOutput != "" {
 				t.Errorf("runCommand: expects errors, got nil")
 				return
@@ -40,10 +45,10 @@ func TestRunCommand(t *testing.T) {
 		})
 	})
 	t.Run("paren", func(t *testing.T) {
-		commandOutput, err := runCommand([]string{
+		commandOutput, err := runCommand(ctx, []string{
 			"echo",
 			"$(echo test)",
-		})
+		}, to, nil)
 		if err != nil {
 			t.Errorf("runCommand: %s", err)
 			return
@@ -53,10 +58,10 @@ func TestRunCommand(t *testing.T) {
 			return
 		}
 		t.Run("error", func(t *testing.T) {
-			commandOutput, err := runCommand([]string{
+			commandOutput, err := runCommand(ctx, []string{
 				"echo",
 				fmt.Sprintf("`%s/a_binary_name_that_will_never_appear_in_syspath`", t.TempDir()),
-			})
+			}, to, nil)
 			if err == nil || commandOutput != "" {
 				t.Errorf("runCommand: expects errors, got nil")
 				return
@@ -67,10 +72,10 @@ func TestRunCommand(t *testing.T) {
 		})
 	})
 	t.Run("braces", func(t *testing.T) {
-		commandOutput, err := runCommand([]string{
+		commandOutput, err := runCommand(ctx, []string{
 			"echo",
 			"${echo test}",
-		})
+		}, to, nil)
 		if err != nil {
 			t.Errorf("runCommand: %s", err)
 			return
@@ -80,10 +85,10 @@ func TestRunCommand(t *testing.T) {
 			return
 		}
 		t.Run("error", func(t *testing.T) {
-			commandOutput, err := runCommand([]string{
+			commandOutput, err := runCommand(ctx, []string{
 				"echo",
 				fmt.Sprintf("`%s/a_binary_name_that_will_never_appear_in_syspath`", t.TempDir()),
-			})
+			}, to, nil)
 			if err == nil || commandOutput != "" {
 				t.Errorf("runCommand: expects errors, got nil")
 				return
@@ -94,10 +99,10 @@ func TestRunCommand(t *testing.T) {
 		})
 	})
 	t.Run("nested", func(t *testing.T) {
-		commandOutput, err := runCommand([]string{
+		commandOutput, err := runCommand(ctx, []string{
 			"echo",
 			"${echo $(echo `echo \"test\"`)}",
-		})
+		}, to, nil)
 		if err != nil {
 			t.Errorf("runCommand: %s", err)
 			return
@@ -107,10 +112,10 @@ func TestRunCommand(t *testing.T) {
 			return
 		}
 		t.Run("error", func(t *testing.T) {
-			commandOutput, err := runCommand([]string{
+			commandOutput, err := runCommand(ctx, []string{
 				"echo",
 				fmt.Sprintf("`%s/a_binary_name_that_will_never_appear_in_syspath`", t.TempDir()),
-			})
+			}, to, nil)
 			if err == nil || commandOutput != "" {
 				t.Errorf("runCommand: expects errors, got nil")
 				return
@@ -121,9 +126,9 @@ func TestRunCommand(t *testing.T) {
 		})
 	})
 	t.Run("empty", func(t *testing.T) {
-		commandOutput, err := runCommand([]string{
+		commandOutput, err := runCommand(ctx, []string{
 			"${}",
-		})
+		}, to, nil)
 		if err != nil {
 			t.Errorf("runCommand: %s", err)
 			return
@@ -133,6 +138,59 @@ func TestRunCommand(t *testing.T) {
 			return
 		}
 	})
+	t.Run("timeout_kills_slow_process", func(t *testing.T) {
+		start := time.Now()
+		_, err := runCommand(ctx, []string{"sleep", "5"}, 100*time.Millisecond, nil)
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatalf("runCommand: expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("runCommand: expected timeout error, got %s", err)
+		}
+		if elapsed > 4*time.Second {
+			t.Fatalf("runCommand: timeout did not kill child promptly (took %s)", elapsed)
+		}
+	})
+	t.Run("env_scrubbed", func(t *testing.T) {
+		t.Setenv("DEFC_TEST_SECRET", "sentinel-xyz-shouldnt-leak")
+		out, err := runCommand(ctx, []string{"env"}, to, nil)
+		if err != nil {
+			t.Fatalf("runCommand: %s", err)
+		}
+		if strings.Contains(out, "DEFC_TEST_SECRET") || strings.Contains(out, "sentinel-xyz-shouldnt-leak") {
+			t.Fatalf("runCommand: expected scrubbed env, DEFC_TEST_SECRET leaked into child\n%s", out)
+		}
+	})
+	t.Run("env_allowlist_passes_through", func(t *testing.T) {
+		t.Setenv("DEFC_TEST_ALLOWED", "allowed-value")
+		out, err := runCommand(ctx, []string{"env"}, to, []string{"DEFC_TEST_ALLOWED"})
+		if err != nil {
+			t.Fatalf("runCommand: %s", err)
+		}
+		if !strings.Contains(out, "DEFC_TEST_ALLOWED=allowed-value") {
+			t.Fatalf("runCommand: expected DEFC_TEST_ALLOWED to pass through, got:\n%s", out)
+		}
+	})
+	t.Run("relative_argv0_rejected", func(t *testing.T) {
+		_, err := runCommand(ctx, []string{"./attacker"}, to, nil)
+		if err == nil {
+			t.Fatalf("runCommand: expected rejection for relative argv[0]")
+		}
+		if !strings.Contains(err.Error(), "relative path") &&
+			!strings.Contains(err.Error(), "not found in PATH") {
+			t.Fatalf("runCommand: expected relative-path rejection, got %s", err)
+		}
+	})
+	t.Run("context_cancel_propagates", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(ctx)
+		cancel()
+		_, err := runCommand(cctx, []string{"sleep", "5"}, 10*time.Second, nil)
+		if err == nil {
+			t.Fatalf("runCommand: expected error from cancelled context")
+		}
+	})
+	_ = os.Getenv // keep os imported for Setenv compatibility across Go versions
 }
 
 func TestSplitArgs(t *testing.T) {

--- a/gen/tools_test.go
+++ b/gen/tools_test.go
@@ -7,7 +7,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -190,7 +189,6 @@ func TestRunCommand(t *testing.T) {
 			t.Fatalf("runCommand: expected error from cancelled context")
 		}
 	})
-	_ = os.Getenv // keep os imported for Setenv compatibility across Go versions
 }
 
 func TestSplitArgs(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 	"go/format"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	goimport "golang.org/x/tools/imports"
@@ -70,7 +72,18 @@ var (
 	funcs             []string
 	targetType        string
 	template          string
+
+	// generate-time security knobs
+	allowScript      bool
+	scriptTimeoutStr string
+	scriptTimeout    time.Duration
+	scriptEnvAllow   []string
+	includeRoots     []string
 )
+
+const scriptTimeoutUpperBound = 10 * time.Minute
+
+var scriptEnvNameRe = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 
 var (
 	defc = &cobra.Command{
@@ -179,7 +192,11 @@ defc provides the following three scenarios of code generation features:
 				WithPkg(os.Getenv(EnvGoPackage)).
 				WithPwd(pwd).
 				WithFile(file, doc).
-				WithPos(pos)
+				WithPos(pos).
+				WithAllowScript(allowScript).
+				WithScriptTimeout(scriptTimeout).
+				WithScriptEnv(scriptEnvAllow).
+				WithIncludeRoots(includeRoots)
 
 			var buffer bytes.Buffer
 			if err = builder.Build(&buffer); err != nil {
@@ -299,7 +316,11 @@ type defc should handle using the '--type/-T' parameter to avoid generating inco
 					WithPwd(pwd).
 					WithFile(file, doc).
 					WithPos(pos).
-					WithTemplate(template)
+					WithTemplate(template).
+					WithAllowScript(allowScript).
+					WithScriptTimeout(scriptTimeout).
+					WithScriptEnv(scriptEnvAllow).
+					WithIncludeRoots(includeRoots)
 				var buffer bytes.Buffer
 				if err = builder.Build(&buffer); err != nil {
 					return err
@@ -350,6 +371,77 @@ func checkFlags() (err error) {
 	if err = checkFeatures(features); err != nil {
 		return err
 	}
+	if err = checkScriptFlags(); err != nil {
+		return err
+	}
+	if err = checkIncludeRoots(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkScriptFlags parses and validates the three #SCRIPT-related knobs.
+// Populates the package-level `scriptTimeout` from `scriptTimeoutStr`.
+func checkScriptFlags() error {
+	scriptTimeout = 0
+	if scriptTimeoutStr != "" {
+		d, perr := time.ParseDuration(scriptTimeoutStr)
+		if perr != nil {
+			return fmt.Errorf("--script-timeout must be a valid duration, got %q: %w", scriptTimeoutStr, perr)
+		}
+		if d < 0 {
+			return fmt.Errorf("--script-timeout must be non-negative, got %q", scriptTimeoutStr)
+		}
+		if d > scriptTimeoutUpperBound {
+			return fmt.Errorf("--script-timeout exceeds 10m upper bound, got %q", scriptTimeoutStr)
+		}
+		scriptTimeout = d
+	}
+	if !allowScript {
+		if scriptTimeoutStr != "" || len(scriptEnvAllow) > 0 {
+			return errors.New("--script-timeout and --script-env require --allow-script")
+		}
+	}
+	for _, name := range scriptEnvAllow {
+		if name == "" || strings.Contains(name, "=") || !scriptEnvNameRe.MatchString(name) {
+			return fmt.Errorf("--script-env %q is not a valid environment variable name", name)
+		}
+	}
+	return nil
+}
+
+// checkIncludeRoots validates each --include-root entry.
+func checkIncludeRoots() error {
+	for _, root := range includeRoots {
+		if !filepath.IsAbs(root) {
+			return fmt.Errorf("--include-root %q must be an absolute path", root)
+		}
+		cleaned := filepath.Clean(root)
+		if cleaned != root {
+			return fmt.Errorf("--include-root %q must be a cleaned absolute path (no \"..\" or trailing separators)", root)
+		}
+		fi, err := os.Stat(root)
+		if err != nil || !fi.IsDir() {
+			return fmt.Errorf("--include-root %q does not exist or is not a directory", root)
+		}
+		// Reject any symlink in the resolved path.
+		current := ""
+		parts := strings.Split(root, string(os.PathSeparator))
+		if filepath.IsAbs(root) {
+			current = string(os.PathSeparator)
+		}
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			current = filepath.Join(current, part)
+			if lfi, lerr := os.Lstat(current); lerr == nil {
+				if lfi.Mode()&os.ModeSymlink != 0 {
+					return fmt.Errorf("--include-root %q contains a symlink at %q", root, current)
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -398,6 +490,15 @@ func init() {
 	flags.StringArrayVar(&funcs, "func", nil, "additional funcs")
 	flags.StringArrayVar(&funcs, "function", nil, "additional funcs")
 
+	flags.BoolVar(&allowScript, "allow-script", false,
+		"allow #SCRIPT directives to execute commands at generate time (deprecated; see SECURITY.md)")
+	flags.StringVar(&scriptTimeoutStr, "script-timeout", "",
+		"hard timeout for each #SCRIPT invocation (requires --allow-script)")
+	flags.StringArrayVar(&scriptEnvAllow, "script-env", nil,
+		"extra environment variable NAMES to pass through to #SCRIPT (repeatable; values are copied from the current process env; requires --allow-script)")
+	flags.StringArrayVar(&includeRoots, "include-root", nil,
+		"additional filesystem roots that #INCLUDE absolute paths may resolve under (repeatable; must be existing absolute directories)")
+
 	// [2024-04-07]
 	// Since we use the `checkFlags` function to validate required parameters,
 	// we can disable Cobra's check for required flags.
@@ -417,5 +518,7 @@ func init() {
 }
 
 func main() {
-	cobra.CheckErr(defc.Execute())
+	if err := defc.Execute(); err != nil {
+		cobra.CheckErr(err)
+	}
 }


### PR DESCRIPTION
sqlx header directives `#INCLUDE` and `#SCRIPT` were unconstrained at
generate time: `#INCLUDE` joined caller-controlled paths with pwd and
`#SCRIPT` `exec.Command`'d arbitrary argv with the generator's inherited
environment (SSH keys, CI tokens) and no timeout or stderr cap. This
is a generate-time arbitrary-file-read + RCE.

- `#INCLUDE` now anchors to the schema file's directory (or an
  explicitly-configured `--include-root`), rejects `..` escapes and
  symlink components via an lstat walk, enforces 1 MiB per-file and
  4 MiB aggregate caps, and sorts glob matches deterministically.
  Diagnostics include the originating `file:line`.
- `#SCRIPT` is gated behind `--allow-script` (default OFF). When enabled
  it runs with a scrubbed env (`PATH`/`HOME`/`USER`/`LANG`/`LC_ALL`/
  `LC_CTYPE`/`TMPDIR`/`GOCACHE`/`GOMODCACHE`/`GOPATH` baseline, plus
  `--script-env=NAME` allow-listing), a bounded wall-clock timeout
  (`--script-timeout`, default 10s, max 10m), and a 64 KiB stderr cap.
  `PATH` lookup uses a local `lookPathIn` against the scrubbed env.
  Bare relative `argv[0]` containing a slash is rejected. A deprecation
  warning is emitted on every successful invocation.
- CLI: new persistent flags `--allow-script`, `--script-timeout`,
  `--script-env`, `--include-root` wired through `CliBuilder`
  (`WithAllowScript` / `WithScriptTimeout` / `WithScriptEnv` /
  `WithIncludeRoots`). `checkFlags` gains `checkScriptFlags` and
  `checkIncludeRoots` so misuse is caught at argv parsing rather than
  inside `readHeader`.
- `SECURITY.md` documents the generate-time trust boundary, the
  `#SCRIPT` deprecation timeline (removal in v1.47.0), and the private
  reporting process.
- `gen/method.go` `MetaArgs` gets a one-line comment pointing
  `splitArgs` readers at `SECURITY.md` (`splitArgs` is grouping syntax,
  not shell expansion).

**Breaking under sqlx mode:** paths escaping the schema dir / outside
`--include-root` are rejected, symlink components are rejected,
size-capped files are rejected, and `#SCRIPT` errors by default.

## Verification

- `go build ./...` ✅ (excluding pre-existing `gen/integration/rpc`)
- `go vet ./runtime/... ./gen/...` ✅
- `go test ./runtime/... ./gen/` ✅

Part of the v1.45.0 security release series; supersedes #10.
