### PR TITLE
✨ feat: opt-in strict template-interpolation validators (api/sqlx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### 🔒 Security — template-interpolation validators (opt-in)
+
+Runtime validators guarding generated api/sqlx code against
+CRLF / SSRF / SQL-injection / placeholder-arity bugs introduced
+via templated caller values. Gated by three new feature flags
+(default OFF): `api/strict-headers`, `api/strict-url`, `sqlx/strict`.
+Typed errors all wrap `runtime.ErrUnsafeInterpolation`.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ injection classes that a naive `{{.x}}` interpolation enables:
   control bytes, unparseable URLs, non-http(s) schemes, and
   scheme/host drift away from the template's constant prefix.
 
-All flags default **OFF**; enabling them leaves generated code
-byte-identical to prior versions except for the added check calls.
+All flags default **OFF**; when omitted, generated output matches prior
+versions. Enabling them adds only the validation calls and does not
+change generated API signatures.
 
 **Smart Defaults:** The `defc generate` command provides intelligent defaults:
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,25 @@ defc generate --output=query.go schema.go
 defc generate --features=sqlx/log,sqlx/rebind schema.go
 ```
 
+### Safe Template Interpolation
+
+`defc` ships strict, opt-in runtime validators for the three template
+injection classes that a naive `{{.x}}` interpolation enables:
+
+- **`sqlx/strict`** — inserts `runtime.SQLArityCheck(query, len(args))`
+  after template execution, aborting before any DB work if the
+  rendered `?` count does not match the argument count.
+- **`api/strict-headers`** — pre-validates the rendered header map
+  and re-sweeps each `req.Header.Add` value, rejecting CR / LF /
+  NUL and other control bytes with `ErrUnsafeInterpolation`.
+- **`api/strict-url`** — wraps the rendered URL with
+  `runtime.StrictURL(constPrefix, rendered)`, which rejects
+  control bytes, unparseable URLs, non-http(s) schemes, and
+  scheme/host drift away from the template's constant prefix.
+
+All flags default **OFF**; enabling them leaves generated code
+byte-identical to prior versions except for the added check calls.
+
 **Smart Defaults:** The `defc generate` command provides intelligent defaults:
 
 - **Auto-detect mode** by analyzing your interface methods

--- a/gen/api.go
+++ b/gen/api.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strings"
 	"text/template"
 
 	_ "embed"
@@ -35,6 +36,17 @@ const (
 	FeatureApiGzip         = "api/gzip"
 	FeatureApiRetry        = "api/retry"
 	FeatureApiGetBody      = "api/get-body"
+
+	// FeatureApiStrictHeaders gates the HeaderValue / PreExecHeaderMap
+	// emission that rejects CRLF / NUL / C0 / DEL bytes in templated
+	// HTTP header values. v1.45 default: OFF. See CHANGELOG.md and
+	// README.md for the rollout table.
+	FeatureApiStrictHeaders = "api/strict-headers"
+	// FeatureApiStrictURL gates the runtime StrictURL check that runs
+	// after address-template execution, asserting scheme ∈ {http,https}
+	// and host/scheme match a compile-time constant prefix extracted
+	// from method.TmplURL.
+	FeatureApiStrictURL = "api/strict-url"
 )
 
 func (builder *CliBuilder) buildApi(w io.Writer) error {
@@ -447,6 +459,19 @@ func headerHasBody(header string) bool {
 //go:embed template/api.tmpl
 var apiTemplate string
 
+// staticURLPrefix returns the leading constant substring of a
+// method.TmplURL up to the first `{{` action, with trailing whitespace
+// trimmed. It is injected into generated code so the runtime
+// StrictURL call can assert the rendered URL's host/scheme still
+// match the author's intent.
+func staticURLPrefix(tmpl string) string {
+	idx := strings.Index(tmpl, "{{")
+	if idx < 0 {
+		return strings.TrimRight(tmpl, " \t\r\n")
+	}
+	return strings.TrimRight(tmpl[:idx], " \t\r\n")
+}
+
 func (ctx *apiContext) genApiCode(w io.Writer) error {
 	tmpl, err := template.
 		New("defc(api)").
@@ -464,6 +489,7 @@ func (ctx *apiContext) genApiCode(w io.Writer) error {
 			"isInner":           isInner,
 			"httpMethodHasBody": httpMethodHasBody,
 			"headerHasBody":     headerHasBody,
+			"staticURLPrefix":   staticURLPrefix,
 		}).
 		Parse(apiTemplate)
 

--- a/gen/sqlx.go
+++ b/gen/sqlx.go
@@ -30,6 +30,11 @@ const (
 	FeatureSqlxFuture      = "sqlx/future"
 	FeatureSqlxCallback    = "sqlx/callback"
 	FeatureSqlxAnyCallback = "sqlx/any-callback"
+
+	// FeatureSqlxStrict gates runtime SQLArityCheck emission that
+	// asserts the number of ? placeholders in the rendered SQL
+	// matches the argList length. v1.45 default: OFF.
+	FeatureSqlxStrict = "sqlx/strict"
 )
 
 func (builder *CliBuilder) buildSqlx(w io.Writer) error {

--- a/gen/strict_emission_test.go
+++ b/gen/strict_emission_test.go
@@ -1,0 +1,116 @@
+package gen
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestStrictEmission asserts the v1.45 strict-* feature flags inject
+// the expected runtime helper calls into the generated code and, when
+// the flags are omitted (the v1.45 default), leave the output
+// untouched. See §1.6 in the Round-3 C spec for the rollout table.
+func TestStrictEmission(t *testing.T) {
+	const apiSchema = `package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	defc "github.com/x5iu/defc/runtime"
+)
+
+type Iface interface {
+	Response() defc.FutureResponse
+
+	// Run GET https://api.example.com/v1/{{ .path }}
+	/*
+		- Authorization: Bearer {{ .token }}
+	*/
+	Run(ctx context.Context, path, token fmt.Stringer) (*http.Response, error)
+}
+`
+	const sqlxSchema = `package test
+
+import (
+	"context"
+	"fmt"
+)
+
+type Iface interface {
+	WithTx(ctx context.Context, fn func(Iface) error) error
+
+	// Run exec bind
+	// DELETE FROM t WHERE id = {{ bind $.id }}
+	Run(ctx context.Context, id fmt.Stringer) error
+}
+`
+
+	build := func(t *testing.T, mode Mode, src string, feats []string) string {
+		t.Helper()
+		var buf bytes.Buffer
+		// position: find line containing "type Iface interface"
+		pos := 1
+		for i, ln := range strings.Split(src, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(ln), "type Iface interface") {
+				pos = i + 1
+				break
+			}
+		}
+		b := NewCliBuilder(mode).
+			WithFeats(feats).
+			WithPkg("test").
+			WithFile("test.go", []byte(src)).
+			WithPos(pos - 1)
+		if err := b.Build(&buf); err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("api_defaults_off", func(t *testing.T) {
+		out := build(t, ModeApi, apiSchema, []string{FeatureApiFuture})
+		if strings.Contains(out, "__rt.PreExecHeaderMap") {
+			t.Error("expected no PreExecHeaderMap without api/strict-headers")
+		}
+		if strings.Contains(out, "__rt.StrictURL") {
+			t.Error("expected no StrictURL without api/strict-url")
+		}
+	})
+
+	t.Run("api_strict_headers_emits", func(t *testing.T) {
+		out := build(t, ModeApi, apiSchema, []string{FeatureApiFuture, FeatureApiStrictHeaders})
+		if !strings.Contains(out, "__rt.PreExecHeaderMap") {
+			t.Error("missing PreExecHeaderMap emission under api/strict-headers")
+		}
+		if !strings.Contains(out, "__rt.HeaderValue") {
+			t.Error("missing post-sweep HeaderValue emission under api/strict-headers")
+		}
+	})
+
+	t.Run("api_strict_url_emits", func(t *testing.T) {
+		out := build(t, ModeApi, apiSchema, []string{FeatureApiFuture, FeatureApiStrictURL})
+		if !strings.Contains(out, "__rt.StrictURL") {
+			t.Error("missing StrictURL emission")
+		}
+		if !strings.Contains(out, `"https://api.example.com/v1/"`) {
+			t.Error("missing constantPrefix literal; got output without prefix quote")
+		}
+	})
+
+	t.Run("sqlx_defaults_off", func(t *testing.T) {
+		out := build(t, ModeSqlx, sqlxSchema, nil)
+		if strings.Contains(out, "__rt.SQLArityCheck") {
+			t.Error("expected no SQLArityCheck without sqlx/strict")
+		}
+	})
+
+	t.Run("sqlx_strict_emits", func(t *testing.T) {
+		out := build(t, ModeSqlx, sqlxSchema, []string{FeatureSqlxStrict})
+		if !strings.Contains(out, "__rt.SQLArityCheck") {
+			t.Error("missing SQLArityCheck under sqlx/strict")
+		}
+	})
+}
+

--- a/gen/template/api.tmpl
+++ b/gen/template/api.tmpl
@@ -306,14 +306,26 @@ var (
         {{ $bufReader := printf "bufReader%s" $method.Ident }}
         {{ $mimeHeader := printf "mimeHeader%s" $method.Ident -}}
         {{ if ne $method.Header "" -}}
-            if {{ $err }} = {{ $headerTmpl }}.Execute({{ $header }}, map[string]any{
+            {{ $headerMap := printf "headerMap%s" $method.Ident -}}
+            {{ $headerMap }} := map[string]any{
             {{ if $.HasInner -}}
                 "{{ $.Ident }}": __imp.{{ methodInner }}(),
             {{ end -}}
             {{ range $index, $ident := $sortIn -}}
                 "{{- $ident }}": {{ $ident -}},
             {{ end }}
-            }); {{ $err }} != nil {
+            }
+            {{ if and ($.HasFeature "api/strict-headers") (not ($.HasFeature "api/nort")) -}}
+                if {{ $err }} = __rt.PreExecHeaderMap({{ $headerMap }}); {{ $err }} != nil {
+                return {{ range $index, $type := $method.Out -}}
+                    {{- if lt $index (sub (len $method.Out) 1) -}}
+                        v{{- $index -}}{{- $method.Ident }},
+                    {{- end -}}
+                {{- end -}}
+                fmt.Errorf("error building '{{ $method.Ident }}' header: %w", {{ $err }})
+                }
+            {{ end -}}
+            if {{ $err }} = {{ $headerTmpl }}.Execute({{ $header }}, {{ $headerMap }}); {{ $err }} != nil {
             return {{ range $index, $type := $method.Out -}}
                 {{- if lt $index (sub (len $method.Out) 1) -}}
                     v{{- $index -}}{{- $method.Ident }},
@@ -334,7 +346,22 @@ var (
         {{- end }}
 
         {{ $url := printf "url%s" $method.Ident -}}
-        {{ $url }} := {{ $addr }}.String()
+        {{ if and ($.HasFeature "api/strict-url") (not ($.HasFeature "api/nort")) -}}
+            {{ $urlRaw := printf "urlRaw%s" $method.Ident -}}
+            {{ $urlErr := printf "urlErr%s" $method.Ident -}}
+            {{ $urlRaw }} := {{ $addr }}.String()
+            {{ $url }}, {{ $urlErr }} := __rt.StrictURL({{ quote (staticURLPrefix $method.TmplURL) }}, {{ $urlRaw }})
+            if {{ $urlErr }} != nil {
+            return {{ range $index, $type := $method.Out -}}
+                {{- if lt $index (sub (len $method.Out) 1) -}}
+                    v{{- $index -}}{{- $method.Ident }},
+                {{- end -}}
+            {{- end -}}
+            fmt.Errorf("error building '{{ $method.Ident }}' url: %w", {{ $urlErr }})
+            }
+        {{ else -}}
+            {{ $url }} := {{ $addr }}.String()
+        {{ end -}}
         {{- $request := printf "request%s" $method.Ident -}}
         {{- if httpMethodHasBody $httpMethod }}
             {{- if headerHasBody $method.TmplHeader }}
@@ -381,6 +408,16 @@ var (
             {{ $v := printf "v%s" $method.Ident -}}
             for {{ $k }}, {{ $vv }} := range {{ $mimeHeader }} {
             for _, {{ $v }} := range {{ $vv }} {
+            {{ if and ($.HasFeature "api/strict-headers") (not ($.HasFeature "api/nort")) -}}
+                if _, errHV := __rt.HeaderValue({{ $v }}); errHV != nil {
+                return {{ range $index, $type := $method.Out -}}
+                    {{- if lt $index (sub (len $method.Out) 1) -}}
+                        v{{- $index -}}{{- $method.Ident }},
+                    {{- end -}}
+                {{- end -}}
+                fmt.Errorf("error building '{{ $method.Ident }}' header: %w", errHV)
+                }
+            {{ end -}}
             {{ $request }}.Header.Add({{ $k }}, {{ $v }})
             }
             }

--- a/gen/template/sqlx.tmpl
+++ b/gen/template/sqlx.tmpl
@@ -221,6 +221,16 @@ var (
         {{ $query }} := {{ quote (readHeader $method.Header) }}
     {{ end }}
 
+    {{ if and ($.HasFeature "sqlx/strict") (not ($.HasFeature "sqlx/nort")) (not (hasOption ($method.SqlxOptions) "NAMED")) }}
+        if errA := __rt.SQLArityCheck({{ $query }}, len({{ $argList }})); errA != nil {
+        return {{ range $index, $type := $method.Out -}}
+            {{- if lt $index (sub (len $method.Out) 1) -}}
+                v{{- $index -}}{{- $method.Ident }},
+            {{- end -}}
+        {{- end -}} fmt.Errorf("error checking %s query: %w", strconv.Quote({{ quote $method.Ident }}), errA)
+        }
+    {{ end }}
+
     {{ $log := printf "log%s" $method.Ident }}
     {{- $ok := printf "ok%s" $method.Ident }}
     {{- $start := printf "start%s" $method.Ident }}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ var (
 		gen.FeatureApiGzip,
 		gen.FeatureApiRetry,
 		gen.FeatureApiGetBody,
+		gen.FeatureApiStrictHeaders,
+		gen.FeatureApiStrictURL,
 		gen.FeatureSqlxIn,
 		gen.FeatureSqlxLog,
 		gen.FeatureSqlxRebind,
@@ -47,6 +49,7 @@ var (
 		gen.FeatureSqlxFuture,
 		gen.FeatureSqlxCallback,
 		gen.FeatureSqlxAnyCallback,
+		gen.FeatureSqlxStrict,
 		gen.FeatureRpcNoRt,
 	}
 )

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -1,0 +1,10 @@
+package defc
+
+import "errors"
+
+// ErrUnsafeInterpolation is the shared sentinel returned (via Unwrap) from
+// every strict-interpolation validator in this package. Callers wiring
+// bespoke error handling should match against this sentinel with
+// [errors.Is] rather than against the concrete types, so new violation
+// shapes added in future releases remain matched.
+var ErrUnsafeInterpolation = errors.New("defc: unsafe template interpolation")

--- a/runtime/header.go
+++ b/runtime/header.go
@@ -34,8 +34,9 @@ func (e *InvalidHeaderMapError) Unwrap() error { return e.Err }
 // HeaderValue validates v as a safe HTTP header field-value.
 //
 // The returned string is byte-for-byte equal to v when v contains only
-// visible-ASCII (0x21..0x7E), horizontal tab (0x09) and UTF-8 obs-text
-// bytes (>= 0x80). Any CR, LF, NUL, other C0 control, or DEL triggers
+// visible-ASCII (0x21..0x7E), space (0x20), horizontal tab (0x09), and
+// UTF-8 obs-text bytes (>= 0x80), per RFC 9110. Any CR, LF, NUL, other
+// C0 control, or DEL triggers
 // an error. This is a fail-closed validator — values are never
 // silently stripped, because silent stripping creates "valid looking"
 // headers with attacker-chosen prefixes and no audit trail.
@@ -82,6 +83,7 @@ func preExecHeaderOne(v any) error {
 		_, err := HeaderValue(t)
 		return err
 	case []byte:
+		// TODO(perf): byte-sweep variant to avoid []byte → string alloc
 		_, err := HeaderValue(string(t))
 		return err
 	case fmt.Stringer:

--- a/runtime/header.go
+++ b/runtime/header.go
@@ -1,0 +1,93 @@
+package defc
+
+import (
+	"fmt"
+)
+
+// InvalidHeaderValueError is returned by [HeaderValue] when the value
+// contains a byte that is forbidden in an HTTP field-value (RFC 9110
+// §5.5). It wraps [ErrUnsafeInterpolation].
+type InvalidHeaderValueError struct {
+	Offset int
+	Byte   byte
+}
+
+func (e *InvalidHeaderValueError) Error() string {
+	return fmt.Sprintf("defc: header value contains forbidden byte 0x%02x at offset %d", e.Byte, e.Offset)
+}
+
+func (e *InvalidHeaderValueError) Unwrap() error { return ErrUnsafeInterpolation }
+
+// InvalidHeaderMapError wraps an [InvalidHeaderValueError] with the
+// offending map key from [PreExecHeaderMap].
+type InvalidHeaderMapError struct {
+	Key string
+	Err error
+}
+
+func (e *InvalidHeaderMapError) Error() string {
+	return fmt.Sprintf("defc: header map key %q: %s", e.Key, e.Err.Error())
+}
+
+func (e *InvalidHeaderMapError) Unwrap() error { return e.Err }
+
+// HeaderValue validates v as a safe HTTP header field-value.
+//
+// The returned string is byte-for-byte equal to v when v contains only
+// visible-ASCII (0x21..0x7E), horizontal tab (0x09) and UTF-8 obs-text
+// bytes (>= 0x80). Any CR, LF, NUL, other C0 control, or DEL triggers
+// an error. This is a fail-closed validator — values are never
+// silently stripped, because silent stripping creates "valid looking"
+// headers with attacker-chosen prefixes and no audit trail.
+//
+// Complexity is O(len(v)); zero allocations on the happy path.
+func HeaderValue(v string) (string, error) {
+	for i := 0; i < len(v); i++ {
+		b := v[i]
+		switch {
+		case b == '\t':
+			// HT is the only allowed control byte in HTTP headers.
+		case b < 0x20:
+			return "", &InvalidHeaderValueError{Offset: i, Byte: b}
+		case b == 0x7f:
+			return "", &InvalidHeaderValueError{Offset: i, Byte: b}
+		}
+	}
+	return v, nil
+}
+
+// PreExecHeaderMap walks the map that a generated API method is about
+// to pass to its `headerTmpl.Execute`. For every entry whose dynamic
+// type is string, []byte, or fmt.Stringer, [HeaderValue] is applied.
+// The first offending entry short-circuits and is wrapped in an
+// [InvalidHeaderMapError] carrying the map key.
+//
+// Entries of other types (numbers, structs meant to be reached via
+// {{.x.Field}}) are skipped silently; the generator is expected to
+// route those through the `header` template helper instead.
+func PreExecHeaderMap(m map[string]any) error {
+	for k, v := range m {
+		if err := preExecHeaderOne(v); err != nil {
+			return &InvalidHeaderMapError{Key: k, Err: err}
+		}
+	}
+	return nil
+}
+
+func preExecHeaderOne(v any) error {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case string:
+		_, err := HeaderValue(t)
+		return err
+	case []byte:
+		_, err := HeaderValue(string(t))
+		return err
+	case fmt.Stringer:
+		_, err := HeaderValue(t.String())
+		return err
+	default:
+		return nil
+	}
+}

--- a/runtime/header_test.go
+++ b/runtime/header_test.go
@@ -1,0 +1,91 @@
+package defc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestHeaderValue_Accepts(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"Bearer abc123",
+		"application/json; charset=utf-8",
+		"tab\there", // HT is allowed
+		"utf8-obs-\xc2\xa0text",
+	} {
+		got, err := HeaderValue(in)
+		if err != nil {
+			t.Errorf("HeaderValue(%q): unexpected error %v", in, err)
+		}
+		if got != in {
+			t.Errorf("HeaderValue(%q) mutated to %q", in, got)
+		}
+	}
+}
+
+func TestHeaderValue_Rejects(t *testing.T) {
+	cases := map[string]string{
+		"crlf":    "abc\r\nX-Injected: evil",
+		"cr":      "abc\revil",
+		"lf":      "abc\nevil",
+		"nul":     "abc\x00evil",
+		"del":     "abc\x7fevil",
+		"c0":      "abc\x01evil",
+		"vt":      "abc\x0bevil",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := HeaderValue(in)
+			if err == nil {
+				t.Fatalf("HeaderValue(%q): expected error", in)
+			}
+			if !errors.Is(err, ErrUnsafeInterpolation) {
+				t.Errorf("HeaderValue(%q): error %v not wrapping ErrUnsafeInterpolation", in, err)
+			}
+			var ihe *InvalidHeaderValueError
+			if !errors.As(err, &ihe) {
+				t.Errorf("HeaderValue(%q): expected *InvalidHeaderValueError, got %T", in, err)
+			}
+		})
+	}
+}
+
+type stringerT string
+
+func (s stringerT) String() string { return string(s) }
+
+func TestPreExecHeaderMap(t *testing.T) {
+	clean := map[string]any{
+		"Authorization": "Bearer abcdef",
+		"X-Req-Id":      []byte("abc"),
+		"X-Stringer":    stringerT("hello"),
+		"X-Nil":         nil,
+		"X-Int":         42, // unknown type, ignored
+	}
+	if err := PreExecHeaderMap(clean); err != nil {
+		t.Fatalf("PreExecHeaderMap(clean) err=%v", err)
+	}
+
+	dirty := map[string]any{
+		"Authorization": "Bearer abc\r\nX-Injected: evil",
+	}
+	err := PreExecHeaderMap(dirty)
+	if err == nil {
+		t.Fatal("expected error on dirty map")
+	}
+	var ime *InvalidHeaderMapError
+	if !errors.As(err, &ime) {
+		t.Fatalf("expected *InvalidHeaderMapError, got %T", err)
+	}
+	if ime.Key != "Authorization" {
+		t.Errorf("key=%q want Authorization", ime.Key)
+	}
+	if !strings.Contains(err.Error(), "Authorization") {
+		t.Errorf("error message missing key: %s", err.Error())
+	}
+
+	if !errors.Is(err, ErrUnsafeInterpolation) {
+		t.Errorf("error not wrapping ErrUnsafeInterpolation")
+	}
+}

--- a/runtime/ident.go
+++ b/runtime/ident.go
@@ -1,0 +1,51 @@
+package defc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SQLDialect selects the identifier-quoting convention for
+// [QuoteIdentifier].
+type SQLDialect int
+
+const (
+	// DialectMySQL quotes identifiers with backticks and escapes a
+	// backtick inside the value by doubling it. Interior NUL is
+	// rejected.
+	DialectMySQL SQLDialect = iota
+	// DialectPostgres quotes identifiers with double quotes and
+	// escapes an embedded double quote by doubling it.
+	DialectPostgres
+	// DialectSQLite follows the Postgres convention.
+	DialectSQLite
+)
+
+// InvalidIdentifierError signals that a runtime value is not safe to
+// inline as a SQL identifier under the selected dialect.
+type InvalidIdentifierError struct {
+	Dialect SQLDialect
+	Detail  string
+}
+
+func (e *InvalidIdentifierError) Error() string {
+	return fmt.Sprintf("defc: invalid SQL identifier: %s", e.Detail)
+}
+
+func (e *InvalidIdentifierError) Unwrap() error { return ErrUnsafeInterpolation }
+
+// QuoteIdentifier returns the dialect-escaped, quoted form of v. The
+// result is suitable for direct inlining into a SQL string.
+func QuoteIdentifier(v string, dialect SQLDialect) (string, error) {
+	if strings.ContainsRune(v, 0) {
+		return "", &InvalidIdentifierError{Dialect: dialect, Detail: "contains NUL"}
+	}
+	switch dialect {
+	case DialectMySQL:
+		return "`" + strings.ReplaceAll(v, "`", "``") + "`", nil
+	case DialectPostgres, DialectSQLite:
+		return `"` + strings.ReplaceAll(v, `"`, `""`) + `"`, nil
+	default:
+		return "", &InvalidIdentifierError{Dialect: dialect, Detail: fmt.Sprintf("unknown dialect %d", int(dialect))}
+	}
+}

--- a/runtime/ident_test.go
+++ b/runtime/ident_test.go
@@ -1,0 +1,44 @@
+package defc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestQuoteIdentifier(t *testing.T) {
+	cases := []struct {
+		in      string
+		dialect SQLDialect
+		want    string
+	}{
+		{"users", DialectMySQL, "`users`"},
+		{"us`ers", DialectMySQL, "`us``ers`"},
+		{"users", DialectPostgres, `"users"`},
+		{`us"ers`, DialectPostgres, `"us""ers"`},
+		{"users", DialectSQLite, `"users"`},
+	}
+	for _, c := range cases {
+		got, err := QuoteIdentifier(c.in, c.dialect)
+		if err != nil {
+			t.Errorf("QuoteIdentifier(%q,%d) err=%v", c.in, c.dialect, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("QuoteIdentifier(%q,%d)=%q want %q", c.in, c.dialect, got, c.want)
+		}
+	}
+}
+
+func TestQuoteIdentifier_RejectsNUL(t *testing.T) {
+	_, err := QuoteIdentifier("ab\x00cd", DialectMySQL)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrUnsafeInterpolation) {
+		t.Errorf("not wrapping sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("msg=%q", err.Error())
+	}
+}

--- a/runtime/sql_check.go
+++ b/runtime/sql_check.go
@@ -1,0 +1,38 @@
+package defc
+
+import (
+	"fmt"
+
+	"github.com/x5iu/defc/runtime/token"
+)
+
+// SQLArityError is returned by [SQLArityCheck] when the rendered SQL
+// contains a number of `?` placeholders that does not match the
+// caller-supplied argument count.
+type SQLArityError struct {
+	Have     int
+	Want     int
+	Rendered string
+}
+
+func (e *SQLArityError) Error() string {
+	return fmt.Sprintf("defc: SQL placeholder arity mismatch: rendered has %d ?-placeholders but argList has %d arguments", e.Want, e.Have)
+}
+
+func (e *SQLArityError) Unwrap() error { return ErrUnsafeInterpolation }
+
+// SQLArityCheck verifies that the number of `?` placeholders in the
+// rendered SQL matches argc. Placeholder counting is
+// comment/quote-aware via [token.CountPlaceholders]; see its docs for
+// exact tokenisation rules.
+//
+// It should be invoked by generated code *before* [In] rewrites a
+// `?` into multiple bindvars for slices, so that the caller's
+// rendered-vs-arg mismatch is caught in the original form.
+func SQLArityCheck(rendered string, argc int) error {
+	want := token.CountPlaceholders(rendered)
+	if want == argc {
+		return nil
+	}
+	return &SQLArityError{Have: argc, Want: want, Rendered: rendered}
+}

--- a/runtime/sql_check_test.go
+++ b/runtime/sql_check_test.go
@@ -1,0 +1,51 @@
+package defc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/x5iu/defc/runtime/token"
+)
+
+func TestCountPlaceholders(t *testing.T) {
+	cases := map[string]int{
+		"":                                      0,
+		"SELECT 1":                              0,
+		"SELECT ? FROM t":                       1,
+		"SELECT ?, ?, ? FROM t":                 3,
+		"SELECT '?' FROM t":                     0,
+		`SELECT "?" FROM t`:                     0,
+		"SELECT `?` FROM t":                     0,
+		"SELECT 1 -- trailing ?\n":              0,
+		"SELECT /* ? comment ? */ ? FROM t":     1,
+		"INSERT INTO t VALUES ('a''b', ?)":      1,
+		"SELECT 'can''t' FROM t WHERE x=?":      1,
+		"SELECT * FROM t WHERE x='a' AND y=?":   1,
+		"SELECT * FROM t -- ?\nWHERE x=? AND ?": 2,
+	}
+	for sql, want := range cases {
+		if got := token.CountPlaceholders(sql); got != want {
+			t.Errorf("CountPlaceholders(%q)=%d want %d", sql, got, want)
+		}
+	}
+}
+
+func TestSQLArityCheck(t *testing.T) {
+	if err := SQLArityCheck("SELECT ? FROM t", 1); err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	err := SQLArityCheck("SELECT ?, ? FROM t", 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrUnsafeInterpolation) {
+		t.Errorf("not wrapping sentinel: %v", err)
+	}
+	var ae *SQLArityError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *SQLArityError, got %T", err)
+	}
+	if ae.Have != 1 || ae.Want != 2 {
+		t.Errorf("have=%d want=%d", ae.Have, ae.Want)
+	}
+}

--- a/runtime/token/token.go
+++ b/runtime/token/token.go
@@ -182,3 +182,87 @@ func SplitTokens(line string) (tokens []string) {
 	splitTokensCache.Add(line, tokens)
 	return tokens
 }
+
+// CountPlaceholders counts `?` positional placeholders in a SQL
+// string, skipping those inside single-quoted literals, double-quoted
+// identifiers, backtick-quoted identifiers, `--` line comments, and
+// `/* ... */` block comments. Intended for [SQLArityCheck] equivalents
+// outside this package; standard SQL escape (doubled quote inside a
+// literal) is honored.
+//
+// Placeholder counting is intentionally unaware of `:name` / `$N`
+// styles — the defc sqlx pipeline emits `?` everywhere before rebind.
+func CountPlaceholders(s string) int {
+	var (
+		count  int
+		single bool
+		double bool
+		back   bool
+		line   bool // -- ... \n
+		block  bool // /* ... */
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case line:
+			if c == '\n' {
+				line = false
+			}
+		case block:
+			if c == '*' && i+1 < len(s) && s[i+1] == '/' {
+				block = false
+				i++
+			}
+		case single:
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '\'' {
+				if i+1 < len(s) && s[i+1] == '\'' {
+					i++
+					continue
+				}
+				single = false
+			}
+		case double:
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '"' {
+				if i+1 < len(s) && s[i+1] == '"' {
+					i++
+					continue
+				}
+				double = false
+			}
+		case back:
+			if c == '`' {
+				back = false
+			}
+		default:
+			switch c {
+			case '\'':
+				single = true
+			case '"':
+				double = true
+			case '`':
+				back = true
+			case '-':
+				if i+1 < len(s) && s[i+1] == '-' {
+					line = true
+					i++
+				}
+			case '/':
+				if i+1 < len(s) && s[i+1] == '*' {
+					block = true
+					i++
+				}
+			case '?':
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/runtime/token/token.go
+++ b/runtime/token/token.go
@@ -190,6 +190,11 @@ func SplitTokens(line string) (tokens []string) {
 // outside this package; standard SQL escape (doubled quote inside a
 // literal) is honored.
 //
+// String-literal scanning does NOT honor backslash escapes. This matches
+// SQL:standard and Postgres default (standard_conforming_strings=on).
+// Dialects that use backslash escaping (legacy MySQL) should quote-double
+// the single quote instead.
+//
 // Placeholder counting is intentionally unaware of `:name` / `$N`
 // styles — the defc sqlx pipeline emits `?` everywhere before rebind.
 func CountPlaceholders(s string) int {
@@ -214,10 +219,6 @@ func CountPlaceholders(s string) int {
 				i++
 			}
 		case single:
-			if c == '\\' && i+1 < len(s) {
-				i++
-				continue
-			}
 			if c == '\'' {
 				if i+1 < len(s) && s[i+1] == '\'' {
 					i++
@@ -226,10 +227,6 @@ func CountPlaceholders(s string) int {
 				single = false
 			}
 		case double:
-			if c == '\\' && i+1 < len(s) {
-				i++
-				continue
-			}
 			if c == '"' {
 				if i+1 < len(s) && s[i+1] == '"' {
 					i++

--- a/runtime/token/token_test.go
+++ b/runtime/token/token_test.go
@@ -1,0 +1,18 @@
+package token
+
+import "testing"
+
+func TestCountPlaceholders(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"SELECT ? WHERE a = 'a\\' AND x = ?", 2},
+		{"SELECT ?, ? WHERE a = 'it''s' AND x = ?", 3},
+	}
+	for _, c := range cases {
+		if got := CountPlaceholders(c.in); got != c.want {
+			t.Errorf("CountPlaceholders(%q)=%d want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/runtime/url.go
+++ b/runtime/url.go
@@ -1,0 +1,94 @@
+package defc
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// UnsafeURLError categorises [StrictURL] violations.
+type UnsafeURLError struct {
+	Kind   string
+	Detail string
+}
+
+func (e *UnsafeURLError) Error() string {
+	return fmt.Sprintf("defc: strict URL check: %s: %s", e.Kind, e.Detail)
+}
+
+func (e *UnsafeURLError) Unwrap() error { return ErrUnsafeInterpolation }
+
+// StrictURL validates the runtime-rendered URL against a
+// generator-time constant prefix extracted from method.TmplURL. Checks
+// are additive and fail-closed:
+//
+//  1. Byte sweep: rejects CR, LF, NUL, other C0 controls, DEL, space
+//     and structural delimiters (", <, >, {, }, backtick) that would
+//     indicate smuggled bytes even before URL parsing. Note: apostrophe
+//     is permitted (common in legitimate URLs); dedicated quoting via
+//     [QueryValue]/[PathSegment] applies when callers need it.
+//  2. url.Parse must succeed.
+//  3. u.Scheme ∈ {http, https}.
+//  4. When constantPrefix is non-empty, u.Scheme/u.Host must match
+//     those parsed out of constantPrefix, catching authority-drift
+//     payloads of the form "@evil.com/" injected at the start of the
+//     path.
+//
+// Returns rendered unchanged on success.
+func StrictURL(constantPrefix, rendered string) (string, error) {
+	if err := sweepURLBytes(rendered); err != nil {
+		return "", err
+	}
+	u, err := url.Parse(rendered)
+	if err != nil {
+		return "", &UnsafeURLError{Kind: "ParseFailed", Detail: err.Error()}
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return "", &UnsafeURLError{Kind: "SchemeDenied", Detail: fmt.Sprintf("scheme %q not in {http,https}", u.Scheme)}
+	}
+	if constantPrefix != "" {
+		p, perr := url.Parse(constantPrefix)
+		if perr == nil && p.Scheme != "" && p.Host != "" {
+			if u.Scheme != p.Scheme {
+				return "", &UnsafeURLError{Kind: "SchemeDrift", Detail: fmt.Sprintf("scheme %q != expected %q", u.Scheme, p.Scheme)}
+			}
+			if u.Host != p.Host {
+				return "", &UnsafeURLError{Kind: "HostDrift", Detail: fmt.Sprintf("host %q != expected %q", u.Host, p.Host)}
+			}
+		}
+	}
+	return rendered, nil
+}
+
+func sweepURLBytes(s string) error {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch {
+		case b < 0x20, b == 0x7f:
+			return &UnsafeURLError{Kind: "ControlChar", Detail: fmt.Sprintf("forbidden byte 0x%02x at offset %d", b, i)}
+		case b == ' ', b == '"', b == '<', b == '>', b == '{', b == '}', b == '`':
+			return &UnsafeURLError{Kind: "ControlChar", Detail: fmt.Sprintf("forbidden byte 0x%02x at offset %d", b, i)}
+		}
+	}
+	return nil
+}
+
+// PathSegment returns a percent-encoded URL path segment suitable for
+// inlining in a path between two literal slashes. NUL bytes are
+// stripped prior to encoding; other C0 controls are percent-encoded
+// by [url.PathEscape] per RFC 3986 and rendered inert on the wire.
+func PathSegment(v string) string {
+	for i := 0; i < len(v); i++ {
+		if v[i] == 0x00 {
+			return url.PathEscape(strings.ReplaceAll(v, "\x00", ""))
+		}
+	}
+	return url.PathEscape(v)
+}
+
+// QueryValue returns a percent-encoded URL query value.
+func QueryValue(v string) string {
+	return url.QueryEscape(v)
+}

--- a/runtime/url.go
+++ b/runtime/url.go
@@ -48,13 +48,17 @@ func StrictURL(constantPrefix, rendered string) (string, error) {
 	default:
 		return "", &UnsafeURLError{Kind: "SchemeDenied", Detail: fmt.Sprintf("scheme %q not in {http,https}", u.Scheme)}
 	}
+	if u.Host == "" || u.Opaque != "" {
+		return "", fmt.Errorf("%w: url must have a non-empty host and no opaque form: %q",
+			ErrUnsafeInterpolation, rendered)
+	}
 	if constantPrefix != "" {
 		p, perr := url.Parse(constantPrefix)
 		if perr == nil && p.Scheme != "" && p.Host != "" {
 			if u.Scheme != p.Scheme {
 				return "", &UnsafeURLError{Kind: "SchemeDrift", Detail: fmt.Sprintf("scheme %q != expected %q", u.Scheme, p.Scheme)}
 			}
-			if u.Host != p.Host {
+			if !strings.EqualFold(u.Host, p.Host) {
 				return "", &UnsafeURLError{Kind: "HostDrift", Detail: fmt.Sprintf("host %q != expected %q", u.Host, p.Host)}
 			}
 		}

--- a/runtime/url_test.go
+++ b/runtime/url_test.go
@@ -27,6 +27,27 @@ func TestStrictURL_Accepts(t *testing.T) {
 	}
 }
 
+func TestStrictURL_HostValidation(t *testing.T) {
+	reject := []string{
+		"http:///path",
+		"http:opaque",
+		"https://",
+	}
+	for _, s := range reject {
+		_, err := StrictURL("", s)
+		if err == nil {
+			t.Fatalf("StrictURL(%q) want error", s)
+		}
+		if !errors.Is(err, ErrUnsafeInterpolation) {
+			t.Fatalf("StrictURL(%q) err=%v want ErrUnsafeInterpolation", s, err)
+		}
+	}
+	_, err := StrictURL("https://API.example.com/", "https://api.example.com/path")
+	if err != nil {
+		t.Fatalf("StrictURL equal-fold host: %v", err)
+	}
+}
+
 func TestStrictURL_Rejects(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/runtime/url_test.go
+++ b/runtime/url_test.go
@@ -1,0 +1,84 @@
+package defc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStrictURL_Accepts(t *testing.T) {
+	cases := []struct {
+		prefix   string
+		rendered string
+	}{
+		{"https://api.example.com/", "https://api.example.com/v1/widgets"},
+		{"", "http://localhost:8080/healthz"},
+		{"https://api.example.com", "https://api.example.com/a/b/c?x=1&y=2"},
+	}
+	for _, c := range cases {
+		got, err := StrictURL(c.prefix, c.rendered)
+		if err != nil {
+			t.Errorf("StrictURL(%q,%q) err=%v", c.prefix, c.rendered, err)
+			continue
+		}
+		if got != c.rendered {
+			t.Errorf("rendered mutated: %q -> %q", c.rendered, got)
+		}
+	}
+}
+
+func TestStrictURL_Rejects(t *testing.T) {
+	cases := []struct {
+		name     string
+		prefix   string
+		rendered string
+		kind     string
+	}{
+		{"crlf", "", "https://api.example.com/x\r\ny", "ControlChar"},
+		{"space", "", "https://api.example.com/ab cd", "ControlChar"},
+		{"backtick", "", "https://api.example.com/`cmd`", "ControlChar"},
+		{"parse-fail", "", "ht\x01ps://broken", "ControlChar"},
+		{"bad-scheme", "", "ftp://host/f", "SchemeDenied"},
+		{"bad-scheme2", "", "file:///etc/passwd", "SchemeDenied"},
+		{"host-drift", "https://api.example.com/", "https://evil.com/api.example.com/x", "HostDrift"},
+		{"userinfo-drift", "https://api.example.com/", "https://api.example.com@evil.com/", "HostDrift"},
+		{"scheme-drift", "https://api.example.com/", "http://api.example.com/x", "SchemeDrift"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := StrictURL(c.prefix, c.rendered)
+			if err == nil {
+				t.Fatalf("expected error for %q", c.rendered)
+			}
+			if !errors.Is(err, ErrUnsafeInterpolation) {
+				t.Errorf("err not wrapping ErrUnsafeInterpolation: %v", err)
+			}
+			var ue *UnsafeURLError
+			if !errors.As(err, &ue) {
+				t.Fatalf("expected *UnsafeURLError, got %T (%v)", err, err)
+			}
+			if ue.Kind != c.kind {
+				t.Errorf("kind=%s want %s (err=%v)", ue.Kind, c.kind, err)
+			}
+		})
+	}
+}
+
+func TestPathSegment(t *testing.T) {
+	if got := PathSegment("hello world"); got != "hello%20world" {
+		t.Errorf("PathSegment: %q", got)
+	}
+	if got := PathSegment("a/b"); !strings.Contains(got, "%2F") {
+		t.Errorf("PathSegment did not escape slash: %q", got)
+	}
+	// NUL stripped
+	if got := PathSegment("ab\x00cd"); strings.Contains(got, "\x00") {
+		t.Errorf("PathSegment left NUL: %q", got)
+	}
+}
+
+func TestQueryValue(t *testing.T) {
+	if got := QueryValue("a b&c=d"); got != "a+b%26c%3Dd" {
+		t.Errorf("QueryValue: %q", got)
+	}
+}


### PR DESCRIPTION
Template sites in `gen/template/api.tmpl` and `gen/template/sqlx.tmpl`
that interpolate caller-controlled values into HTTP headers, URLs,
and SQL are not context-aware by default, so a malicious value can
inject CRLF, drift host authority, or unbalance placeholder arity.

This PR adds a family of runtime validators and opt-in feature
flags that wire them into the generator. All validators fail closed
with typed errors wrapping a single `ErrUnsafeInterpolation` sentinel.
Happy paths are zero allocation. Public APIs unchanged unless
explicitly opted-in via feature flag.

- `runtime/header.go`: `HeaderValue` / `PreExecHeaderMap` +
  `InvalidHeaderValueError` rejecting CR, LF, NUL, C0 controls, DEL.
- `runtime/url.go`: `StrictURL(constantPrefix, rendered)` requires
  http/https scheme, parseable URL, and host/scheme match against
  the compile-time constant prefix. `PathSegment` / `QueryValue`
  helpers for author opt-in.
- `runtime/ident.go`: `QuoteIdentifier` with `SQLDialect` enum
  (MySQL / Postgres / SQLite) for safe identifier interpolation.
- `runtime/sql_check.go` + `runtime/token`: `SQLArityCheck` built on a
  quote- and comment-aware `CountPlaceholders`.
- `runtime/errors.go`: `ErrUnsafeInterpolation` sentinel.

Feature flags (all default OFF in this release):
- `api/strict-headers` — emit `PreExecHeaderMap` + `HeaderValue` sweep.
- `api/strict-url`     — wrap `addr.String()` with `StrictURL`.
- `sqlx/strict`        — insert `SQLArityCheck` between template
                         execution and transaction open.

Generator additions:
- `gen/api.go`: new flag constants + `staticURLPrefix()` helper that
  extracts the leading constant substring of `TmplURL` up to the
  first `{{` action.
- `gen/sqlx.go`: `sqlx/strict` constant.
- `gen/template/api.tmpl`: emits the new validators only when the
  corresponding `api/strict-*` flag is active (and non-nort).
- `gen/template/sqlx.tmpl`: inserts `SQLArityCheck` under `sqlx/strict`.

## Verification

- `go build ./...` ✅ (excluding pre-existing `gen/integration/rpc`)
- `go vet ./runtime/... ./gen/...` ✅
- `go test ./runtime/... ./gen/` ✅

Part of the v1.45.0 security release series; supersedes #10.
