### PR TITLE
✨ feat: opt-in sqlx/strict-merge for NAMED-arg collision detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### 🔒 Security — strict NAMED-arg merge (opt-in)
+
+New feature `sqlx/strict-merge` turns silent bind-key collisions in
+NAMED-merge into fail-closed errors wrapping
+`runtime.ErrNamedArgsCollision`. A companion fuzz test,
+`runtime/merge_fuzz_test.go`, asserts that strict-merge never loses a
+key without reporting it. Default OFF; opt-in per-schema via the new
+feature flag.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ defc generate --output=query.go schema.go
 defc generate --features=sqlx/log,sqlx/rebind schema.go
 ```
 
+### Strict NAMED-arg Merge
+
+Opt-in `sqlx/strict-merge` makes `NAMED` parameter merging return an
+error when two distinct sources contribute the same bind key (e.g. a
+struct field and a map key both named `id`), instead of silently
+letting one overwrite the other. Errors wrap
+`runtime.ErrNamedArgsCollision` and carry the provenance labels of
+the colliding contributors.
+
 **Smart Defaults:** The `defc generate` command provides intelligent defaults:
 
 - **Auto-detect mode** by analyzing your interface methods

--- a/gen/sqlx.go
+++ b/gen/sqlx.go
@@ -30,6 +30,11 @@ const (
 	FeatureSqlxFuture      = "sqlx/future"
 	FeatureSqlxCallback    = "sqlx/callback"
 	FeatureSqlxAnyCallback = "sqlx/any-callback"
+
+	// FeatureSqlxStrictMerge makes named-arg merging return an error
+	// when two distinct sources contribute the same bind key. See
+	// runtime.MergeNamedArgsStrict.
+	FeatureSqlxStrictMerge = "sqlx/strict-merge"
 )
 
 func (builder *CliBuilder) buildSqlx(w io.Writer) error {

--- a/gen/strict_emission_test.go
+++ b/gen/strict_emission_test.go
@@ -1,0 +1,71 @@
+package gen
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestStrictMergeEmission asserts the sqlx/strict-merge feature flag
+// rewrites NAMED arg collection to MergeNamedArgsStrict with
+// error-propagation (non-nort) or inlines the strict merger body
+// (nort). See CHANGELOG for the v1.45.x rollout.
+func TestStrictMergeEmission(t *testing.T) {
+	const namedSchema = `package test
+
+import (
+	"context"
+	"fmt"
+)
+
+type Iface interface {
+	WithTx(ctx context.Context, fn func(Iface) error) error
+
+	// Run exec named
+	// DELETE FROM t WHERE id = :id
+	Run(ctx context.Context, id fmt.Stringer) error
+}
+`
+
+	build := func(t *testing.T, mode Mode, src string, feats []string) string {
+		t.Helper()
+		var buf bytes.Buffer
+		pos := 1
+		for i, ln := range strings.Split(src, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(ln), "type Iface interface") {
+				pos = i + 1
+				break
+			}
+		}
+		b := NewCliBuilder(mode).
+			WithFeats(feats).
+			WithPkg("test").
+			WithFile("test.go", []byte(src)).
+			WithPos(pos - 1)
+		if err := b.Build(&buf); err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("sqlx_strict_merge_nonnort", func(t *testing.T) {
+		out := build(t, ModeSqlx, namedSchema, []string{FeatureSqlxStrictMerge})
+		if !strings.Contains(out, "__rt.MergeNamedArgsStrict") {
+			t.Error("missing MergeNamedArgsStrict emission under sqlx/strict-merge")
+		}
+		if !strings.Contains(out, "error merging") {
+			t.Error("missing merge error-propagation block")
+		}
+	})
+
+	t.Run("sqlx_strict_merge_nort", func(t *testing.T) {
+		out := build(t, ModeSqlx, namedSchema,
+			[]string{FeatureSqlxNoRt, FeatureSqlxStrictMerge})
+		if !strings.Contains(out, "(map[string]any, error)") {
+			t.Error("nort+strict-merge must emit two-return inline body")
+		}
+		if !strings.Contains(out, "ToNamedArgs(") {
+			t.Error("nort+strict-merge inline body missing source labels")
+		}
+	})
+}

--- a/gen/strict_emission_test.go
+++ b/gen/strict_emission_test.go
@@ -67,5 +67,8 @@ type Iface interface {
 		if !strings.Contains(out, "ToNamedArgs(") {
 			t.Error("nort+strict-merge inline body missing source labels")
 		}
+		if !strings.Contains(out, "rv.IsNil()") {
+			t.Error("nort+strict-merge inline body missing typed-nil guard")
+		}
 	})
 }

--- a/gen/template/sqlx.tmpl
+++ b/gen/template/sqlx.tmpl
@@ -627,12 +627,25 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     func {{ $mergeNamedArgsFunc }}(argsMap map[string]any) (map[string]any, error) {
     namedMap := make(map[string]any, len(argsMap))
     provenance := make(map[string]string, len(argsMap))
+    collisionIndex := make(map[string]int)
     var collisions []struct{ Key string; Sources []string }
     put := func(k string, v any, src string) {
     if prev, ok := provenance[k]; ok && prev != src {
+    if idx, have := collisionIndex[k]; have {
+    c := &collisions[idx]
+    dup := false
+    for _, s := range c.Sources {
+    if s == src { dup = true; break }
+    }
+    if !dup {
+    c.Sources = append(c.Sources, src)
+    }
+    } else {
     collisions = append(collisions, struct{ Key string; Sources []string }{
     Key: k, Sources: []string{prev, src},
     })
+    collisionIndex[k] = len(collisions) - 1
+    }
     return
     }
     namedMap[k] = v
@@ -669,8 +682,13 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     }
     }
     } else if rv.Kind() == reflect.Struct ||
-    (rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct) {
-    rv = reflect.Indirect(rv)
+    (rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Struct) {
+    if rv.Kind() == reflect.Pointer {
+    if rv.IsNil() {
+    continue
+    }
+    rv = rv.Elem()
+    }
     rt := rv.Type()
     for i := 0; i < rt.NumField(); i++ {
     if sf := rt.Field(i); sf.Anonymous {
@@ -679,16 +697,28 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     sft = sft.Elem()
     }
     for j := 0; j < sft.NumField(); j++ {
-    if tag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+    if rawTag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+    if rawTag == "-" {
+    continue
+    }
+    tag := rawTag
+    if idx := strings.Index(tag, ","); idx >= 0 {
+    tag = tag[:idx]
+    }
     tag = truncateTag(tag)
-    if tag == "" { continue }
     put(tag, rv.FieldByIndex([]int{i, j}).Interface(),
     "struct("+name+"."+sf.Name+"."+sft.Field(j).Name+")")
     }
     }
-    } else if tag, exists := sf.Tag.Lookup("db"); exists {
+    } else if rawTag, exists := sf.Tag.Lookup("db"); exists {
+    if rawTag == "-" {
+    continue
+    }
+    tag := rawTag
+    if idx := strings.Index(tag, ","); idx >= 0 {
+    tag = tag[:idx]
+    }
     tag = truncateTag(tag)
-    if tag == "" { continue }
     put(tag, rv.Field(i).Interface(),
     "struct("+name+"."+sf.Name+")")
     }
@@ -702,7 +732,18 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     }
     parts := make([]string, 0, len(collisions))
     for _, c := range collisions {
-    parts = append(parts, fmt.Sprintf("defc: duplicate bind key %q contributed by %s and %s", c.Key, c.Sources[0], c.Sources[1]))
+    var joined string
+    switch len(c.Sources) {
+    case 0:
+    joined = "<unknown>"
+    case 1:
+    joined = c.Sources[0]
+    case 2:
+    joined = c.Sources[0] + " and " + c.Sources[1]
+    default:
+    joined = strings.Join(c.Sources[:len(c.Sources)-1], ", ") + " and " + c.Sources[len(c.Sources)-1]
+    }
+    parts = append(parts, fmt.Sprintf("defc: duplicate bind key %q contributed by %s", c.Key, joined))
     }
     return nil, fmt.Errorf("%s", strings.Join(parts, "; "))
     }

--- a/gen/template/sqlx.tmpl
+++ b/gen/template/sqlx.tmpl
@@ -253,6 +253,23 @@ var (
     {{ $offset := printf "offset%s" $method.Ident -}}
     {{ $args := printf "args%s" $method.Ident -}}
     {{ if hasOption ($method.SqlxOptions) "NAMED" }}
+        {{ if $.HasFeature "sqlx/strict-merge" -}}
+        {{ $args }}, {{ $err }} := {{ if $.HasFeature "sqlx/nort" }}{{ $mergeNamedArgsFunc }}{{ else }}__rt.MergeNamedArgsStrict{{ end }}(map[string]any{
+        {{ range $index, $ident := $sortIn -}}
+            {{ if not (isContextType $ident (index $method.In $ident)) -}}
+                {{- quote $ident }}: {{ $ident -}},
+            {{ end -}}
+        {{ end }}
+        })
+        if {{ $err }} != nil {
+        if !__imp.__withTx { {{ $tx }}.Rollback() }
+        return {{ range $index, $type := $method.Out -}}
+            {{- if lt $index (sub (len $method.Out) 1) -}}
+                v{{- $index -}}{{- $method.Ident }},
+            {{- end -}}
+        {{- end -}} fmt.Errorf("error merging %s named args: %w", strconv.Quote({{ quote $method.Ident }}), {{ $err }})
+        }
+        {{- else -}}
         {{ $args }} := {{ if $.HasFeature "sqlx/nort" }}{{ $mergeNamedArgsFunc }}{{ else }}__rt.MergeNamedArgs{{ end }}(map[string]any{
         {{ range $index, $ident := $sortIn -}}
             {{ if not (isContextType $ident (index $method.In $ident)) -}}
@@ -260,6 +277,7 @@ var (
             {{ end -}}
         {{ end }}
         })
+        {{- end }}
     {{- else }}
         {{ $offset }} := 0
         {{- if $.HasFeature "sqlx/in" }}
@@ -605,6 +623,90 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     return dst
     }
 
+    {{ if $.HasFeature "sqlx/strict-merge" -}}
+    func {{ $mergeNamedArgsFunc }}(argsMap map[string]any) (map[string]any, error) {
+    namedMap := make(map[string]any, len(argsMap))
+    provenance := make(map[string]string, len(argsMap))
+    var collisions []struct{ Key string; Sources []string }
+    put := func(k string, v any, src string) {
+    if prev, ok := provenance[k]; ok && prev != src {
+    collisions = append(collisions, struct{ Key string; Sources []string }{
+    Key: k, Sources: []string{prev, src},
+    })
+    return
+    }
+    namedMap[k] = v
+    provenance[k] = src
+    }
+    truncateTag := func(tag string) string {
+    for pos, char := range tag {
+    if !(('0' <= char && char <= '9') || ('a' <= char && char <= 'z') || ('A' <= char && char <= 'Z') || char == '_') {
+    return tag[:pos]
+    }
+    }
+    return tag
+    }
+    for name, arg := range argsMap {
+    rv := reflect.ValueOf(arg)
+    if _, notAnArg := arg.({{ $notAnArg }}); notAnArg {
+    continue
+    } else if toNamedArgs, ok := arg.({{ $toNamedArgs }}); ok {
+    src := "ToNamedArgs(" + name + ")"
+    for k, v := range toNamedArgs.ToNamedArgs() {
+    put(k, v, src)
+    }
+    } else if _, ok = arg.(driver.Valuer); ok {
+    put(name, arg, "driver.Valuer("+name+")")
+    } else if _, ok = arg.({{ $toArgs }}); ok {
+    put(name, arg, "ToArgs("+name+")")
+    } else if rv.Kind() == reflect.Map {
+    src := "map(" + name + ")"
+    iter := rv.MapRange()
+    for iter.Next() {
+    k, v := iter.Key(), iter.Value()
+    if k.Kind() == reflect.String {
+    put(k.String(), v.Interface(), src)
+    }
+    }
+    } else if rv.Kind() == reflect.Struct ||
+    (rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct) {
+    rv = reflect.Indirect(rv)
+    rt := rv.Type()
+    for i := 0; i < rt.NumField(); i++ {
+    if sf := rt.Field(i); sf.Anonymous {
+    sft := sf.Type
+    if sft.Kind() == reflect.Pointer {
+    sft = sft.Elem()
+    }
+    for j := 0; j < sft.NumField(); j++ {
+    if tag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+    tag = truncateTag(tag)
+    if tag == "" { continue }
+    put(tag, rv.FieldByIndex([]int{i, j}).Interface(),
+    "struct("+name+"."+sf.Name+"."+sft.Field(j).Name+")")
+    }
+    }
+    } else if tag, exists := sf.Tag.Lookup("db"); exists {
+    tag = truncateTag(tag)
+    if tag == "" { continue }
+    put(tag, rv.Field(i).Interface(),
+    "struct("+name+"."+sf.Name+")")
+    }
+    }
+    } else {
+    put(name, arg, "scalar("+name+")")
+    }
+    }
+    if len(collisions) == 0 {
+    return namedMap, nil
+    }
+    parts := make([]string, 0, len(collisions))
+    for _, c := range collisions {
+    parts = append(parts, fmt.Sprintf("defc: duplicate bind key %q contributed by %s and %s", c.Key, c.Sources[0], c.Sources[1]))
+    }
+    return nil, fmt.Errorf("%s", strings.Join(parts, "; "))
+    }
+    {{- else -}}
     func {{ $mergeNamedArgsFunc }}(argsMap map[string]any) map[string]any {
     namedMap := make(map[string]any, len(argsMap))
     for name, arg := range argsMap {
@@ -664,6 +766,7 @@ CoreBeginTx(ctx context.Context, opts *sql.TxOptions) ({{ $coreTxInterface }}, e
     }
     return namedMap
     }
+    {{- end }}
 
     func {{ $bindVarsFunc }}(data any) string {
     var n int

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 		gen.FeatureSqlxFuture,
 		gen.FeatureSqlxCallback,
 		gen.FeatureSqlxAnyCallback,
+		gen.FeatureSqlxStrictMerge,
 		gen.FeatureRpcNoRt,
 	}
 )

--- a/runtime/merge.go
+++ b/runtime/merge.go
@@ -173,17 +173,35 @@ func (es NamedArgsCollisionErrors) Unwrap() []error {
 // is either *[NamedArgsCollisionError] (single collision) or
 // [NamedArgsCollisionErrors] (multiple collisions). On error the
 // returned map is nil.
+func containsString(s []string, e string) bool {
+	for i := range s {
+		if s[i] == e {
+			return true
+		}
+	}
+	return false
+}
+
 func MergeNamedArgsStrict(argsMap map[string]any) (map[string]any, error) {
 	namedMap := make(map[string]any, len(argsMap))
 	provenance := make(map[string]string, len(argsMap))
+	collisionIndex := map[string]int{}
 	var collisions []NamedArgsCollisionError
 
 	put := func(k string, v any, src string) {
 		if prev, ok := provenance[k]; ok && prev != src {
-			collisions = append(collisions, NamedArgsCollisionError{
-				Key:     k,
-				Sources: []string{prev, src},
-			})
+			if idx, ok2 := collisionIndex[k]; ok2 {
+				existing := &collisions[idx]
+				if !containsString(existing.Sources, src) {
+					existing.Sources = append(existing.Sources, src)
+				}
+			} else {
+				collisions = append(collisions, NamedArgsCollisionError{
+					Key:     k,
+					Sources: []string{prev, src},
+				})
+				collisionIndex[k] = len(collisions) - 1
+			}
 			return
 		}
 		namedMap[k] = v
@@ -213,8 +231,13 @@ func MergeNamedArgsStrict(argsMap map[string]any) (map[string]any, error) {
 				}
 			}
 		} else if rv.Kind() == reflect.Struct ||
-			(rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct) {
-			rv = reflect.Indirect(rv)
+			(rv.Kind() == reflect.Pointer && rv.Type().Elem().Kind() == reflect.Struct) {
+			if rv.Kind() == reflect.Pointer {
+				if rv.IsNil() {
+					continue
+				}
+				rv = rv.Elem()
+			}
 			rt := rv.Type()
 			for i := 0; i < rt.NumField(); i++ {
 				if sf := rt.Field(i); sf.Anonymous {
@@ -223,21 +246,29 @@ func MergeNamedArgsStrict(argsMap map[string]any) (map[string]any, error) {
 						sft = sft.Elem()
 					}
 					for j := 0; j < sft.NumField(); j++ {
-						if tag, exists := sft.Field(j).Tag.Lookup("db"); exists {
-							tag = truncateDBTag(tag)
-							if tag == "" {
+						if rawTag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+							if rawTag == "-" {
 								continue
 							}
+							tag := rawTag
+							if idx := strings.Index(tag, ","); idx >= 0 {
+								tag = tag[:idx]
+							}
+							tag = truncateDBTag(tag)
 							put(tag,
 								rv.FieldByIndex([]int{i, j}).Interface(),
 								"struct("+name+"."+sf.Name+"."+sft.Field(j).Name+")")
 						}
 					}
-				} else if tag, exists := sf.Tag.Lookup("db"); exists {
-					tag = truncateDBTag(tag)
-					if tag == "" {
+				} else if rawTag, exists := sf.Tag.Lookup("db"); exists {
+					if rawTag == "-" {
 						continue
 					}
+					tag := rawTag
+					if idx := strings.Index(tag, ","); idx >= 0 {
+						tag = tag[:idx]
+					}
+					tag = truncateDBTag(tag)
 					put(tag, rv.Field(i).Interface(),
 						"struct("+name+"."+sf.Name+")")
 				}

--- a/runtime/merge.go
+++ b/runtime/merge.go
@@ -3,7 +3,9 @@ package defc
 import (
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 
 	tok "github.com/x5iu/defc/runtime/token"
 )
@@ -102,6 +104,169 @@ func MergeNamedArgs(argsMap map[string]any) map[string]any {
 		}
 	}
 	return namedMap
+}
+
+// ErrNamedArgsCollision is the sentinel wrapped by every error
+// returned from [MergeNamedArgsStrict]. Use [errors.Is] to detect it.
+var ErrNamedArgsCollision = errors.New("defc: duplicate bind key")
+
+// NamedArgsCollisionError describes a single duplicate bind key. The
+// Sources slice carries the provenance labels of the two (or more)
+// contributors, in discovery order. Because Go randomises map
+// iteration the slice order is not stable across runs; treat it as a
+// set.
+type NamedArgsCollisionError struct {
+	Key     string
+	Sources []string
+}
+
+func (e *NamedArgsCollisionError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	var joined string
+	switch len(e.Sources) {
+	case 0:
+		joined = "<unknown>"
+	case 1:
+		joined = e.Sources[0]
+	case 2:
+		joined = e.Sources[0] + " and " + e.Sources[1]
+	default:
+		joined = strings.Join(e.Sources[:len(e.Sources)-1], ", ") + " and " + e.Sources[len(e.Sources)-1]
+	}
+	return fmt.Sprintf("defc: duplicate bind key %q contributed by %s", e.Key, joined)
+}
+
+func (e *NamedArgsCollisionError) Unwrap() error { return ErrNamedArgsCollision }
+
+// NamedArgsCollisionErrors aggregates multiple collisions discovered
+// during a single merge call. It reports `errors.Is(err,
+// ErrNamedArgsCollision)` true and exposes each entry for
+// [errors.As] traversal.
+type NamedArgsCollisionErrors []NamedArgsCollisionError
+
+func (es NamedArgsCollisionErrors) Error() string {
+	parts := make([]string, 0, len(es))
+	for i := range es {
+		parts = append(parts, (&es[i]).Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (es NamedArgsCollisionErrors) Is(target error) bool {
+	return target == ErrNamedArgsCollision
+}
+
+func (es NamedArgsCollisionErrors) Unwrap() []error {
+	out := make([]error, len(es))
+	for i := range es {
+		e := es[i]
+		out[i] = &e
+	}
+	return out
+}
+
+// MergeNamedArgsStrict behaves like [MergeNamedArgs] except that any
+// duplicate bind key contributed by two distinct sources returns an
+// error that wraps [ErrNamedArgsCollision]. The concrete error type
+// is either *[NamedArgsCollisionError] (single collision) or
+// [NamedArgsCollisionErrors] (multiple collisions). On error the
+// returned map is nil.
+func MergeNamedArgsStrict(argsMap map[string]any) (map[string]any, error) {
+	namedMap := make(map[string]any, len(argsMap))
+	provenance := make(map[string]string, len(argsMap))
+	var collisions []NamedArgsCollisionError
+
+	put := func(k string, v any, src string) {
+		if prev, ok := provenance[k]; ok && prev != src {
+			collisions = append(collisions, NamedArgsCollisionError{
+				Key:     k,
+				Sources: []string{prev, src},
+			})
+			return
+		}
+		namedMap[k] = v
+		provenance[k] = src
+	}
+
+	for name, arg := range argsMap {
+		rv := reflect.ValueOf(arg)
+		if _, notAnArg := arg.(NotAnArg); notAnArg {
+			continue
+		} else if toNamedArgs, ok := arg.(ToNamedArgs); ok {
+			src := "ToNamedArgs(" + name + ")"
+			for k, v := range toNamedArgs.ToNamedArgs() {
+				put(k, v, src)
+			}
+		} else if _, ok = arg.(driver.Valuer); ok {
+			put(name, arg, "driver.Valuer("+name+")")
+		} else if _, ok = arg.(ToArgs); ok {
+			put(name, arg, "ToArgs("+name+")")
+		} else if rv.Kind() == reflect.Map {
+			src := "map(" + name + ")"
+			iter := rv.MapRange()
+			for iter.Next() {
+				k, v := iter.Key(), iter.Value()
+				if k.Kind() == reflect.String {
+					put(k.String(), v.Interface(), src)
+				}
+			}
+		} else if rv.Kind() == reflect.Struct ||
+			(rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct) {
+			rv = reflect.Indirect(rv)
+			rt := rv.Type()
+			for i := 0; i < rt.NumField(); i++ {
+				if sf := rt.Field(i); sf.Anonymous {
+					sft := sf.Type
+					if sft.Kind() == reflect.Pointer {
+						sft = sft.Elem()
+					}
+					for j := 0; j < sft.NumField(); j++ {
+						if tag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+							tag = truncateDBTag(tag)
+							if tag == "" {
+								continue
+							}
+							put(tag,
+								rv.FieldByIndex([]int{i, j}).Interface(),
+								"struct("+name+"."+sf.Name+"."+sft.Field(j).Name+")")
+						}
+					}
+				} else if tag, exists := sf.Tag.Lookup("db"); exists {
+					tag = truncateDBTag(tag)
+					if tag == "" {
+						continue
+					}
+					put(tag, rv.Field(i).Interface(),
+						"struct("+name+"."+sf.Name+")")
+				}
+			}
+		} else {
+			put(name, arg, "scalar("+name+")")
+		}
+	}
+
+	if len(collisions) == 0 {
+		return namedMap, nil
+	}
+	if len(collisions) == 1 {
+		c := collisions[0]
+		return nil, &c
+	}
+	return nil, NamedArgsCollisionErrors(collisions)
+}
+
+func truncateDBTag(tag string) string {
+	for pos, char := range tag {
+		if !(('0' <= char && char <= '9') ||
+			('a' <= char && char <= 'z') ||
+			('A' <= char && char <= 'Z') ||
+			char == '_') {
+			return tag[:pos]
+		}
+	}
+	return tag
 }
 
 func BindVars(data any) string {

--- a/runtime/merge_fuzz_test.go
+++ b/runtime/merge_fuzz_test.go
@@ -1,0 +1,110 @@
+package defc
+
+import (
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+type fuzzReqBody struct {
+	TenantID string `db:"tenant_id"`
+	Name     string `db:"name"`
+}
+
+type fuzzTenantCtx struct {
+	ID string `db:"tenant_id"`
+}
+
+type fuzzNilable struct {
+	X int `db:"x"`
+}
+
+// buildCorpus walks raw bytes into a synthetic map[string]any
+// drawing from primitives, maps, slices, pointers and small
+// struct implementors. The exact layout does not matter; it just
+// needs to exercise every branch of MergeNamedArgsStrict.
+func buildCorpus(data []byte) map[string]any {
+	m := make(map[string]any)
+	if len(data) == 0 {
+		return m
+	}
+	keys := []string{"a", "b", "c", "d", "tenant_id", "name"}
+	for i := 0; i < len(data); {
+		k := keys[int(data[i])%len(keys)]
+		i++
+		if i >= len(data) {
+			break
+		}
+		kind := data[i] % 10
+		i++
+		switch kind {
+		case 0:
+			m[k] = int(data[i%len(data)])
+		case 1:
+			m[k] = string(data[i%len(data) : fuzzMin(i%len(data)+2, len(data))])
+		case 2:
+			m[k] = []int{1, 2, 3}
+		case 3:
+			m[k] = map[string]any{"tenant_id": "x", "extra": int(data[i%len(data)])}
+		case 4:
+			m[k] = fuzzReqBody{TenantID: "r", Name: "n"}
+		case 5:
+			m[k] = fuzzTenantCtx{ID: "t"}
+		case 6:
+			m[k] = (map[string]any)(nil)
+		case 7:
+			m[k] = (*fuzzNilable)(nil)
+		case 8:
+			m[k] = nil
+		case 9:
+			m[k] = map[int]string{1: "a"}
+		}
+	}
+	return m
+}
+
+func fuzzMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func FuzzMergeNamedArgsStrict(f *testing.F) {
+	f.Add([]byte{0x00, 0x01, 0x02, 0x03})
+	f.Add([]byte{0x04, 0x05, 0x01, 0x03})
+	f.Add(binary.BigEndian.AppendUint32(nil, 0xdeadbeef))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		corpus := buildCorpus(data)
+		// Property 1: strict never panics on arbitrary synthetic inputs.
+		strictMap, strictErr := MergeNamedArgsStrict(corpus)
+		// Property 2: any error wraps ErrNamedArgsCollision.
+		if strictErr != nil {
+			if !errors.Is(strictErr, ErrNamedArgsCollision) {
+				t.Fatalf("strict error not Is(ErrNamedArgsCollision): %T %v", strictErr, strictErr)
+			}
+			if strictMap != nil {
+				t.Fatalf("strict returned partial map alongside error")
+			}
+		}
+		// Property 3: on success, key set matches legacy MergeNamedArgs.
+		if strictErr == nil {
+			legacy := MergeNamedArgs(corpus)
+			if !reflect.DeepEqual(sortedKeys(legacy), sortedKeys(strictMap)) {
+				t.Fatalf("key sets diverged legacy=%v strict=%v",
+					sortedKeys(legacy), sortedKeys(strictMap))
+			}
+		}
+	})
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/runtime/merge_fuzz_test.go
+++ b/runtime/merge_fuzz_test.go
@@ -1,10 +1,10 @@
 package defc
 
 import (
+	"database/sql/driver"
 	"encoding/binary"
 	"errors"
 	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -72,15 +72,46 @@ func fuzzMin(a, b int) int {
 	return b
 }
 
+func stringSetEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isNilStructPointerArg(arg any) bool {
+	if arg == nil {
+		return false
+	}
+	rv := reflect.ValueOf(arg)
+	return rv.Kind() == reflect.Pointer &&
+		rv.Type().Elem().Kind() == reflect.Struct &&
+		rv.IsNil()
+}
+
+func dropNilStructPointerEntries(argsMap map[string]any) map[string]any {
+	out := make(map[string]any, len(argsMap))
+	for k, v := range argsMap {
+		if isNilStructPointerArg(v) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 func FuzzMergeNamedArgsStrict(f *testing.F) {
 	f.Add([]byte{0x00, 0x01, 0x02, 0x03})
 	f.Add([]byte{0x04, 0x05, 0x01, 0x03})
 	f.Add(binary.BigEndian.AppendUint32(nil, 0xdeadbeef))
 	f.Fuzz(func(t *testing.T, data []byte) {
 		corpus := buildCorpus(data)
-		// Property 1: strict never panics on arbitrary synthetic inputs.
 		strictMap, strictErr := MergeNamedArgsStrict(corpus)
-		// Property 2: any error wraps ErrNamedArgsCollision.
 		if strictErr != nil {
 			if !errors.Is(strictErr, ErrNamedArgsCollision) {
 				t.Fatalf("strict error not Is(ErrNamedArgsCollision): %T %v", strictErr, strictErr)
@@ -88,23 +119,114 @@ func FuzzMergeNamedArgsStrict(f *testing.F) {
 			if strictMap != nil {
 				t.Fatalf("strict returned partial map alongside error")
 			}
-		}
-		// Property 3: on success, key set matches legacy MergeNamedArgs.
-		if strictErr == nil {
-			legacy := MergeNamedArgs(corpus)
-			if !reflect.DeepEqual(sortedKeys(legacy), sortedKeys(strictMap)) {
-				t.Fatalf("key sets diverged legacy=%v strict=%v",
-					sortedKeys(legacy), sortedKeys(strictMap))
+			saw := false
+			eachNamedArgsCollision(strictErr, func(_ NamedArgsCollisionError) { saw = true })
+			if !saw {
+				t.Fatalf("expected at least one NamedArgsCollisionError in chain: %T", strictErr)
 			}
+			want := legacyMergeOverwrittenKeys(corpus)
+			got := keysFromCollisions(strictErr)
+			if !stringSetEqual(got, want) {
+				t.Fatalf("collision key set: got %v want %v", got, want)
+			}
+			return
+		}
+		legacy := MergeNamedArgs(dropNilStructPointerEntries(corpus))
+		if !reflect.DeepEqual(legacy, strictMap) {
+			t.Fatalf("maps diverged legacy=%#v strict=%#v", legacy, strictMap)
 		}
 	})
 }
 
-func sortedKeys(m map[string]any) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
+func assignLegacy(namedMap map[string]any, overwrites map[string]struct{}, k string, v any) {
+	if _, ok := namedMap[k]; ok {
+		overwrites[k] = struct{}{}
 	}
-	sort.Strings(out)
+	namedMap[k] = v
+}
+
+func legacyMergeOverwrittenKeys(argsMap map[string]any) map[string]struct{} {
+	overwrites := make(map[string]struct{})
+	namedMap := make(map[string]any, len(argsMap))
+	for name, arg := range argsMap {
+		if isNilStructPointerArg(arg) {
+			continue
+		}
+		rv := reflect.ValueOf(arg)
+		if _, notAnArg := arg.(NotAnArg); notAnArg {
+			continue
+		} else if toNamedArgs, ok := arg.(ToNamedArgs); ok {
+			for k, v := range toNamedArgs.ToNamedArgs() {
+				assignLegacy(namedMap, overwrites, k, v)
+			}
+		} else if _, ok = arg.(driver.Valuer); ok {
+			assignLegacy(namedMap, overwrites, name, arg)
+		} else if _, ok = arg.(ToArgs); ok {
+			assignLegacy(namedMap, overwrites, name, arg)
+		} else if rv.Kind() == reflect.Map {
+			iter := rv.MapRange()
+			for iter.Next() {
+				k, v := iter.Key(), iter.Value()
+				if k.Kind() == reflect.String {
+					assignLegacy(namedMap, overwrites, k.String(), v.Interface())
+				}
+			}
+		} else if rv.Kind() == reflect.Struct ||
+			(rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct) {
+			rv = reflect.Indirect(rv)
+			rt := rv.Type()
+			for i := 0; i < rt.NumField(); i++ {
+				if sf := rt.Field(i); sf.Anonymous {
+					sft := sf.Type
+					if sft.Kind() == reflect.Pointer {
+						sft = sft.Elem()
+					}
+					for j := 0; j < sft.NumField(); j++ {
+						if tag, exists := sft.Field(j).Tag.Lookup("db"); exists {
+							for pos, char := range tag {
+								if !(('0' <= char && char <= '9') || ('a' <= char && char <= 'z') || ('A' <= char && char <= 'Z') || char == '_') {
+									tag = tag[:pos]
+									break
+								}
+							}
+							assignLegacy(namedMap, overwrites, tag, rv.FieldByIndex([]int{i, j}).Interface())
+						}
+					}
+				} else if tag, exists := sf.Tag.Lookup("db"); exists {
+					for pos, char := range tag {
+						if !(('0' <= char && char <= '9') || ('a' <= char && char <= 'z') || ('A' <= char && char <= 'Z') || char == '_') {
+							tag = tag[:pos]
+							break
+						}
+					}
+					assignLegacy(namedMap, overwrites, tag, rv.Field(i).Interface())
+				}
+			}
+		} else {
+			assignLegacy(namedMap, overwrites, name, arg)
+		}
+	}
+	return overwrites
+}
+
+func eachNamedArgsCollision(err error, fn func(NamedArgsCollisionError)) {
+	var agg NamedArgsCollisionErrors
+	if errors.As(err, &agg) {
+		for i := range agg {
+			fn(agg[i])
+		}
+		return
+	}
+	var p *NamedArgsCollisionError
+	if errors.As(err, &p) {
+		fn(*p)
+	}
+}
+
+func keysFromCollisions(err error) map[string]struct{} {
+	out := make(map[string]struct{})
+	eachNamedArgsCollision(err, func(e NamedArgsCollisionError) {
+		out[e.Key] = struct{}{}
+	})
 	return out
 }

--- a/runtime/merge_test.go
+++ b/runtime/merge_test.go
@@ -3,6 +3,7 @@ package defc
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -376,5 +377,87 @@ func TestArguments(t *testing.T) {
 	if !reflect.DeepEqual(arguments, Arguments{1, 2, 3}) {
 		t.Errorf("arguments: %v != [1, 2, 3]", arguments)
 		return
+	}
+}
+
+type mergeStrictNilFoo struct {
+	X int `db:"x"`
+}
+
+func TestMergeNamedArgsStrictNilStructPointer(t *testing.T) {
+	m := map[string]any{
+		"p": (*mergeStrictNilFoo)(nil),
+		"q": map[string]any{"b": 1},
+	}
+	strict, err := MergeNamedArgsStrict(m)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	wantKeys := map[string]struct{}{"b": {}}
+	if len(strict) != len(wantKeys) {
+		t.Fatalf("len: got %d want %d", len(strict), len(wantKeys))
+	}
+	for k := range wantKeys {
+		if _, ok := strict[k]; !ok {
+			t.Fatalf("missing %q", k)
+		}
+	}
+}
+
+func TestMergeNamedArgsStrictThreeSourceCollision(t *testing.T) {
+	m := map[string]any{
+		"m1": map[string]any{"k": 1},
+		"m2": map[string]any{"k": 2},
+		"m3": map[string]any{"k": 3},
+	}
+	_, err := MergeNamedArgsStrict(m)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrNamedArgsCollision) {
+		t.Fatalf("err: %v", err)
+	}
+	var one *NamedArgsCollisionError
+	if !errors.As(err, &one) {
+		t.Fatalf("unexpected type: %T", err)
+	}
+	if len(one.Sources) != 3 {
+		t.Fatalf("len(Sources)=%d", len(one.Sources))
+	}
+}
+
+type mergeStrictTagBody struct {
+	A int    `db:""`
+	B int    `db:"only"`
+	C int    `db:"name; charset=utf-8"`
+}
+
+func TestMergeNamedArgsStrictDBTagKeyParityWithLegacy(t *testing.T) {
+	m := map[string]any{
+		"s": mergeStrictTagBody{A: 1, B: 2, C: 3},
+	}
+	legacy := MergeNamedArgs(m)
+	strict, err := MergeNamedArgsStrict(m)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(legacy, strict) {
+		t.Fatalf("diverge legacy=%#v strict=%#v", legacy, strict)
+	}
+}
+
+type mergeStrictWhitespaceDash struct {
+	W int `db:" - "`
+}
+
+func TestMergeStrictPreservesWhitespaceDashTag(t *testing.T) {
+	m := map[string]any{"s": mergeStrictWhitespaceDash{W: 42}}
+	legacy := MergeNamedArgs(m)
+	strict, err := MergeNamedArgsStrict(m)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(legacy, strict) {
+		t.Fatalf("diverge legacy=%#v strict=%#v", legacy, strict)
 	}
 }


### PR DESCRIPTION
`MergeNamedArgs` silently overwrites duplicate bind keys contributed
by distinct sources (e.g. a struct field and a map key both named
`id`). In practice this turns typos and refactors into invisible
parameter corruption: the last iteration wins and the user sees a
wrong row updated, not an error.

This PR adds `runtime.MergeNamedArgsStrict`, a drop-in variant that
tracks the provenance of every key and returns a typed error when
two non-identical sources contribute the same key. Errors wrap
`ErrNamedArgsCollision` and preserve the contributing source labels
for diagnostic output. The existing `MergeNamedArgs` is unchanged.

A new feature flag `sqlx/strict-merge` rewrites the NAMED arg call
site to invoke the strict merger and propagate its error, rolling
back the automatic transaction (when not inside `WithTx`). Under
`sqlx/nort` the inline merge function is emitted with the same
two-return signature.

`runtime/merge_fuzz_test.go` asserts that strict-merge never drops a
bind key without reporting it: for every input either the resulting
map contains every key from every contributing source, or the error
set lists the dropped keys.

Feature flag: `sqlx/strict-merge` (default OFF).

## Verification

- `go build ./...` ✅ (excluding pre-existing `gen/integration/rpc`)
- `go test ./runtime/... ./gen/` ✅

Part of the v1.45.0 security release series; supersedes #10.
