### PR TITLE
feat(sqlx): warn at codegen when template interpolates args outside bind helpers (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- sqlx codegen now emits a warning when a method's SQL template interpolates
+  a method argument as raw SQL text outside bind/bindvars. This surfaces a
+  historical foot-gun (#17) without breaking existing schemas.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,46 @@ Error: template: defc(sqlx):1:45: executing "GetUser" at <.invalid_function>:
 can't evaluate field invalid_function in type map[string]interface {}
 ```
 
+### SQL values: bind, don't interpolate
+
+In the default sqlx template path, values that must be **data** (user-controlled strings, numbers, and so on) must reach the database as bound arguments (`?`), via `CONSTBIND`, or via `{{ bind $.name }}` with the `BIND` option. Interpolating a method argument into the SQL text with `{{ .name }}` splices the Go value directly into the string that is sent to the driver. That bypasses binding, can drop trailing arguments silently at runtime, and is a classic SQL-injection foot-gun (see [issue #17](https://github.com/x5iu/defc/issues/17)). Starting in recent versions, `defc generate` emits a **non-fatal** warning when it detects this pattern.
+
+**DON'T** — the value is pasted into the SQL text; with `name == "' OR 1=1 --"` the query string becomes a tautology:
+
+```go
+// Find query
+// SELECT * FROM users WHERE name = '{{ .name }}';
+Find(ctx context.Context, name string) error
+```
+
+Rendered SQL (illustrative):
+
+```sql
+SELECT * FROM users WHERE name = '' OR 1=1 --';
+```
+
+**DO** — pick one of these patterns:
+
+```go
+// FindPositional query
+// SELECT * FROM users WHERE name = ?;
+FindPositional(ctx context.Context, name string) error
+```
+
+```go
+// FindConstBind query constbind
+// SELECT * FROM users WHERE name = ${name};
+FindConstBind(ctx context.Context, name string) error
+```
+
+```go
+// FindBind query bind
+// SELECT * FROM users WHERE name = {{ bind $.name }};
+FindBind(ctx context.Context, name string) error
+```
+
+Raw `{{ .x }}` is still appropriate when `x` is an **identifier fragment** you control (for example `ORDER BY {{ .col }}` or dynamic table names) after **your own** validation or allow-listing. In those cases a codegen warning is expected; confirm the validation is correct and ignore the warning if appropriate.
+
 ### Advanced Template Patterns
 
 #### Conditional Rendering

--- a/gen/integration/codegen_warn_test.go
+++ b/gen/integration/codegen_warn_test.go
@@ -1,0 +1,61 @@
+//go:build test
+// +build test
+
+package integration
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/x5iu/defc/gen"
+)
+
+func TestCodegenUnsafeInterpWarningStderr(t *testing.T) {
+	const doc = `package main
+
+//go:generate noop
+type Repo interface {
+	// Bad query
+	// SELECT * FROM users WHERE name = '{{ .name }}';
+	Bad(ctx context.Context, name string) error
+}
+`
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	old := os.Stderr
+	os.Stderr = w
+	var buf bytes.Buffer
+	dir := t.TempDir()
+	b := gen.NewCliBuilder(gen.ModeSqlx).
+		WithPkg("main").
+		WithPwd(dir).
+		WithFile("schema.go", []byte(doc)).
+		WithPos(3).
+		WithImports(nil).
+		WithFeats(nil).
+		WithTemplate("").
+		WithFuncs(nil)
+	errBuild := b.Build(&buf)
+	if cerr := w.Close(); cerr != nil {
+		t.Error(cerr)
+	}
+	os.Stderr = old
+	var stderr bytes.Buffer
+	if _, err := io.Copy(&stderr, r); err != nil {
+		t.Fatal(err)
+	}
+	if errBuild != nil {
+		t.Fatalf("build: %v", errBuild)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("defc: warning")) {
+		t.Fatalf("expected warning on stderr, got: %q", stderr.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Raw interpolation")) {
+		t.Fatalf("expected raw interpolation hint, got: %q", stderr.String())
+	}
+}

--- a/gen/sqlx.go
+++ b/gen/sqlx.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 	"text/template"
+	"text/template/parse"
 
 	_ "embed"
 )
@@ -54,6 +55,7 @@ type sqlxContext struct {
 	Imports         []string
 	Funcs           []string
 	Pwd             string
+	File            string
 	Doc             Doc
 	Template        string
 }
@@ -114,11 +116,15 @@ func (ctx *sqlxContext) Build(w io.Writer) error {
 	}
 
 	var bindInvoked bool
-	// Since the text/template standard library does not provide a specific error type, we can only determine whether
-	// the bind function has been invoked in the template through this rudimentary way.
-	if _, err := template.New("detect_bind_function").Parse(ctx.Template); err != nil {
-		bindInvoked = contains(err.Error(), `function "bind" not defined`)
+	if ctx.Template != "" {
+		if trees, err := parse.Parse("defc-root", ctx.Template, "{{", "}}", sqlxParseStubFuncs(ctx)); err == nil {
+			bindInvoked = templateForestReferencesBind(trees)
+		} else {
+			bindInvoked = contains(err.Error(), `function "bind" not defined`)
+		}
 	}
+
+	ctx.emitSqlxUnsafeInterpolationWarnings()
 
 	// Small hack: When the --template/-t option is enabled, and "bind" function has been invoked, the Bind option
 	// is enabled by default for all methods.
@@ -314,6 +320,8 @@ inspectType:
 		Features:  sqlxFeatures,
 		Imports:   builder.imports,
 		Funcs:     builder.funcs,
+		Pwd:       builder.pwd,
+		File:      builder.file,
 		Doc:       builder.doc,
 		Template:  builder.template,
 	}, nil

--- a/gen/unsafe_interp.go
+++ b/gen/unsafe_interp.go
@@ -1,0 +1,359 @@
+package gen
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template/parse"
+)
+
+type UnsafeInterpFinding struct {
+	MethodArg  string
+	Line       int
+	NodeSource string
+}
+
+// scanUnsafeRawInterpolation detects method parameters used as raw SQL outside bind/bindvars (issue #17).
+// User funcs from --func are not trusted as safe sinks; taint through dollar-assign locals is not modeled.
+func scanUnsafeRawInterpolation(tree *parse.Tree, sharedTrees map[string]*parse.Tree, methodArgs map[string]struct{}, allowedSinks map[string]struct{}) []UnsafeInterpFinding {
+	if tree == nil || tree.Root == nil {
+		return nil
+	}
+	return walkTemplateList(tree.Root, true, methodArgs, allowedSinks, sharedTrees)
+}
+
+func walkTemplateList(list *parse.ListNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree) []UnsafeInterpFinding {
+	if list == nil {
+		return nil
+	}
+	var out []UnsafeInterpFinding
+	for _, n := range list.Nodes {
+		out = append(out, walkTemplateNode(n, emitSQL, methodArgs, allowed, shared)...)
+	}
+	return out
+}
+
+func walkTemplateNode(n parse.Node, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree) []UnsafeInterpFinding {
+	switch n := n.(type) {
+	case *parse.TextNode, *parse.CommentNode:
+		return nil
+	case *parse.IfNode:
+		var out []UnsafeInterpFinding
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		return out
+	case *parse.RangeNode:
+		var out []UnsafeInterpFinding
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		return out
+	case *parse.WithNode:
+		var out []UnsafeInterpFinding
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		return out
+	case *parse.ActionNode:
+		if n.Pipe == nil {
+			return nil
+		}
+		if len(n.Pipe.Decl) > 0 || n.Pipe.IsAssign {
+			return findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOfPipe(n.Pipe))
+		}
+		return findPipeFindings(n.Pipe, emitSQL, methodArgs, allowed, shared, lineOfPipe(n.Pipe))
+	case *parse.TemplateNode:
+		var out []UnsafeInterpFinding
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, n.Line)...)
+		if st := shared[n.Name]; st != nil {
+			out = append(out, walkTemplateList(st.Root, emitSQL, methodArgs, allowed, shared)...)
+		}
+		return out
+	case *parse.BreakNode, *parse.ContinueNode:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func lineOf(n parse.Node) int {
+	switch n := n.(type) {
+	case *parse.IfNode:
+		return n.Line
+	case *parse.RangeNode:
+		return n.Line
+	case *parse.WithNode:
+		return n.Line
+	default:
+		return 0
+	}
+}
+
+func lineOfPipe(p *parse.PipeNode) int {
+	if p == nil {
+		return 0
+	}
+	if p.Line > 0 {
+		return p.Line
+	}
+	return 0
+}
+
+func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int) []UnsafeInterpFinding {
+	if pipe == nil {
+		return nil
+	}
+	if len(pipe.Decl) > 0 || pipe.IsAssign {
+		var out []UnsafeInterpFinding
+		for _, cmd := range pipe.Cmds {
+			for _, arg := range cmd.Args {
+				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared)...)
+			}
+		}
+		return out
+	}
+	if !emitSQL {
+		var out []UnsafeInterpFinding
+		for _, cmd := range pipe.Cmds {
+			for _, arg := range cmd.Args {
+				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared)...)
+			}
+		}
+		return out
+	}
+	if pipeAllowedSink(pipe, allowed) {
+		return nil
+	}
+	ln := line
+	if pipe.Line > 0 {
+		ln = pipe.Line
+	}
+	var out []UnsafeInterpFinding
+	for _, cmd := range pipe.Cmds {
+		for _, arg := range cmd.Args {
+			out = append(out, scanArgForRawInterpolation(arg, methodArgs, allowed, shared, ln)...)
+		}
+	}
+	return out
+}
+
+func pipeAllowedSink(pipe *parse.PipeNode, allowed map[string]struct{}) bool {
+	if pipe == nil || len(pipe.Cmds) == 0 {
+		return false
+	}
+	last := pipe.Cmds[len(pipe.Cmds)-1]
+	if len(last.Args) == 0 {
+		return false
+	}
+	id, ok := last.Args[0].(*parse.IdentifierNode)
+	if !ok {
+		return false
+	}
+	_, ok = allowed[id.Ident]
+	return ok
+}
+
+func scanArgForRawInterpolation(n parse.Node, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int) []UnsafeInterpFinding {
+	switch n := n.(type) {
+	case *parse.FieldNode:
+		if len(n.Ident) == 0 {
+			return nil
+		}
+		if _, ok := methodArgs[n.Ident[0]]; !ok {
+			return nil
+		}
+		return []UnsafeInterpFinding{{MethodArg: n.Ident[0], Line: line, NodeSource: strings.TrimSpace(n.String())}}
+	case *parse.VariableNode:
+		if len(n.Ident) >= 2 && n.Ident[0] == "$" {
+			if _, ok := methodArgs[n.Ident[1]]; ok {
+				return []UnsafeInterpFinding{{MethodArg: n.Ident[1], Line: line, NodeSource: strings.TrimSpace(n.String())}}
+			}
+		}
+		return nil
+	case *parse.DotNode:
+		return []UnsafeInterpFinding{{MethodArg: ".", Line: line, NodeSource: n.String()}}
+	case *parse.ChainNode:
+		return scanChainMethodArg(n, methodArgs, line)
+	case *parse.PipeNode:
+		return findPipeFindings(n, true, methodArgs, allowed, shared, line)
+	default:
+		return nil
+	}
+}
+
+func scanChainMethodArg(c *parse.ChainNode, methodArgs map[string]struct{}, line int) []UnsafeInterpFinding {
+	switch r := c.Node.(type) {
+	case *parse.DotNode:
+		if len(c.Field) > 0 {
+			if _, ok := methodArgs[c.Field[0]]; ok {
+				return []UnsafeInterpFinding{{MethodArg: c.Field[0], Line: line, NodeSource: strings.TrimSpace(c.String())}}
+			}
+		}
+	case *parse.VariableNode:
+		if len(r.Ident) >= 2 && r.Ident[0] == "$" {
+			if _, ok := methodArgs[r.Ident[1]]; ok {
+				return []UnsafeInterpFinding{{MethodArg: r.Ident[1], Line: line, NodeSource: strings.TrimSpace(c.String())}}
+			}
+		}
+	}
+	return nil
+}
+
+func sqlxParseStubFuncs(ctx *sqlxContext) map[string]any {
+	fm := map[string]any{
+		"bind":     func(...any) any { return "" },
+		"bindvars": func(...any) any { return "" },
+	}
+	for name := range ctx.AdditionalFuncs() {
+		if _, ok := fm[name]; ok {
+			continue
+		}
+		fm[name] = func(...any) any { return "" }
+	}
+	return fm
+}
+
+func templateForestReferencesBind(trees map[string]*parse.Tree) bool {
+	if trees == nil {
+		return false
+	}
+	for _, tree := range trees {
+		if tree == nil || tree.Root == nil {
+			continue
+		}
+		if walkForestBind(tree.Root, trees) {
+			return true
+		}
+	}
+	return false
+}
+
+func walkForestBind(list *parse.ListNode, shared map[string]*parse.Tree) bool {
+	if list == nil {
+		return false
+	}
+	for _, n := range list.Nodes {
+		if walkNodeBind(n, shared) {
+			return true
+		}
+	}
+	return false
+}
+
+func walkNodeBind(n parse.Node, shared map[string]*parse.Tree) bool {
+	switch n := n.(type) {
+	case *parse.ActionNode:
+		if n.Pipe == nil {
+			return false
+		}
+		for _, cmd := range n.Pipe.Cmds {
+			if len(cmd.Args) == 0 {
+				continue
+			}
+			if id, ok := cmd.Args[0].(*parse.IdentifierNode); ok && id.Ident == "bind" {
+				return true
+			}
+		}
+		for _, cmd := range n.Pipe.Cmds {
+			for _, arg := range cmd.Args {
+				if walkNodeBind(arg, shared) {
+					return true
+				}
+			}
+		}
+		return false
+	case *parse.IfNode:
+		return walkForestBind(n.List, shared) || walkForestBind(n.ElseList, shared)
+	case *parse.RangeNode:
+		return walkForestBind(n.List, shared) || walkForestBind(n.ElseList, shared)
+	case *parse.WithNode:
+		return walkForestBind(n.List, shared) || walkForestBind(n.ElseList, shared)
+	case *parse.TemplateNode:
+		if walkPipeBindArgs(n.Pipe, shared) {
+			return true
+		}
+		if sub := shared[n.Name]; sub != nil && sub.Root != nil {
+			return walkForestBind(sub.Root, shared)
+		}
+		return false
+	case *parse.ListNode:
+		return walkForestBind(n, shared)
+	default:
+		return false
+	}
+}
+
+func walkPipeBindArgs(pipe *parse.PipeNode, shared map[string]*parse.Tree) bool {
+	if pipe == nil {
+		return false
+	}
+	for _, cmd := range pipe.Cmds {
+		for _, arg := range cmd.Args {
+			if walkNodeBind(arg, shared) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (ctx *sqlxContext) methodSQLArgNames(method *Method) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, id := range method.SortIn() {
+		if ctx.Doc.IsContextType(id, method.In[id]) {
+			continue
+		}
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+func (ctx *sqlxContext) emitSqlxUnsafeInterpolationWarnings() {
+	allowed := map[string]struct{}{"bind": {}, "bindvars": {}}
+	stub := sqlxParseStubFuncs(ctx)
+	var sharedTrees map[string]*parse.Tree
+	if ctx.Template != "" {
+		var err error
+		sharedTrees, err = parse.Parse("defc-shared", ctx.Template, "{{", "}}", stub)
+		if err != nil {
+			sharedTrees = nil
+		}
+	}
+	if sharedTrees == nil {
+		sharedTrees = map[string]*parse.Tree{}
+	}
+	for _, method := range ctx.Methods {
+		if method.Ident == sqlxMethodWithTx {
+			continue
+		}
+		opts := method.SqlxOptions()
+		if hasOption(opts, "CONST") || hasOption(opts, "CONSTBIND") || hasOption(opts, "BIND") || hasOption(opts, "NAMED") {
+			continue
+		}
+		body, err := readHeader(method.Header, ctx.Pwd)
+		if err != nil {
+			continue
+		}
+		trees, err := parse.Parse(method.Ident, body, "{{", "}}", stub)
+		if err != nil {
+			continue
+		}
+		tree := trees[method.Ident]
+		if tree == nil {
+			continue
+		}
+		findings := scanUnsafeRawInterpolation(tree, sharedTrees, ctx.methodSQLArgNames(method), allowed)
+		for _, f := range findings {
+			arg := f.MethodArg
+			atLoc := fmt.Sprintf("%s:%d", method.Ident, f.Line)
+			if ctx.File != "" {
+				atLoc = fmt.Sprintf("%s:%d", ctx.File, f.Line)
+			}
+			fmt.Fprintf(os.Stderr, "defc: warning: method %s at %s interpolates argument %q as raw SQL text outside bind/bindvars.\n", method.Ident, atLoc, arg)
+			fmt.Fprintf(os.Stderr, "  This pattern is a SQL-injection foot-gun at runtime. Use {{ bind $.%s }} (requires the `bind` option), CONSTBIND with ${%s}, or positional ? placeholders instead.\n", arg, arg)
+			fmt.Fprintf(os.Stderr, "  Raw interpolation: %s\n", f.NodeSource)
+			fmt.Fprintf(os.Stderr, "  See https://github.com/x5iu/defc/issues/17 for guidance.\n")
+		}
+	}
+}

--- a/gen/unsafe_interp.go
+++ b/gen/unsafe_interp.go
@@ -13,61 +13,73 @@ type UnsafeInterpFinding struct {
 	NodeSource string
 }
 
-// scanUnsafeRawInterpolation detects method parameters used as raw SQL outside bind/bindvars (issue #17).
-// User funcs from --func are not trusted as safe sinks; taint through dollar-assign locals is not modeled.
 func scanUnsafeRawInterpolation(tree *parse.Tree, sharedTrees map[string]*parse.Tree, methodArgs map[string]struct{}, allowedSinks map[string]struct{}) []UnsafeInterpFinding {
 	if tree == nil || tree.Root == nil {
 		return nil
 	}
-	return walkTemplateList(tree.Root, true, methodArgs, allowedSinks, sharedTrees)
+	return walkTemplateList(tree.Root, true, methodArgs, allowedSinks, sharedTrees, "", nil)
 }
 
-func walkTemplateList(list *parse.ListNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree) []UnsafeInterpFinding {
+func walkTemplateList(list *parse.ListNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, taint string, varTaint map[string]string) []UnsafeInterpFinding {
 	if list == nil {
 		return nil
 	}
+	if varTaint == nil {
+		varTaint = map[string]string{}
+	}
 	var out []UnsafeInterpFinding
 	for _, n := range list.Nodes {
-		out = append(out, walkTemplateNode(n, emitSQL, methodArgs, allowed, shared)...)
+		if an, ok := n.(*parse.ActionNode); ok && an.Pipe != nil && len(an.Pipe.Decl) > 0 {
+			addDeclTaints(an.Pipe, methodArgs, varTaint)
+		}
+		out = append(out, walkTemplateNode(n, emitSQL, methodArgs, allowed, shared, taint, varTaint)...)
 	}
 	return out
 }
 
-func walkTemplateNode(n parse.Node, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree) []UnsafeInterpFinding {
+func walkTemplateNode(n parse.Node, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, taint string, varTaint map[string]string) []UnsafeInterpFinding {
 	switch n := n.(type) {
 	case *parse.TextNode, *parse.CommentNode:
 		return nil
 	case *parse.IfNode:
+		locals := copyVarTaint(varTaint)
 		var out []UnsafeInterpFinding
-		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
-		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
-		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n), taint, locals)...)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared, taint, locals)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared, taint, locals)...)
 		return out
 	case *parse.RangeNode:
 		var out []UnsafeInterpFinding
-		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
-		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
-		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n), taint, varTaint)...)
+		locals := copyVarTaint(varTaint)
+		prov := branchTaint(n.Pipe, methodArgs)
+		innerTaint := prov
+		applyRangeDeclTaints(n.Pipe, prov, methodArgs, locals)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared, innerTaint, locals)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared, taint, varTaint)...)
 		return out
 	case *parse.WithNode:
 		var out []UnsafeInterpFinding
-		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n))...)
-		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared)...)
-		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared)...)
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOf(n), taint, varTaint)...)
+		locals := copyVarTaint(varTaint)
+		innerTaint := branchTaint(n.Pipe, methodArgs)
+		out = append(out, walkTemplateList(n.List, emitSQL, methodArgs, allowed, shared, innerTaint, locals)...)
+		out = append(out, walkTemplateList(n.ElseList, emitSQL, methodArgs, allowed, shared, taint, varTaint)...)
 		return out
 	case *parse.ActionNode:
 		if n.Pipe == nil {
 			return nil
 		}
-		if len(n.Pipe.Decl) > 0 || n.Pipe.IsAssign {
-			return findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOfPipe(n.Pipe))
+		if len(n.Pipe.Decl) > 0 {
+			return findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, lineOfPipe(n.Pipe), taint, varTaint)
 		}
-		return findPipeFindings(n.Pipe, emitSQL, methodArgs, allowed, shared, lineOfPipe(n.Pipe))
+		return findPipeFindings(n.Pipe, emitSQL, methodArgs, allowed, shared, lineOfPipe(n.Pipe), taint, varTaint)
 	case *parse.TemplateNode:
 		var out []UnsafeInterpFinding
-		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, n.Line)...)
+		locals := copyVarTaint(varTaint)
+		out = append(out, findPipeFindings(n.Pipe, false, methodArgs, allowed, shared, n.Line, taint, locals)...)
 		if st := shared[n.Name]; st != nil {
-			out = append(out, walkTemplateList(st.Root, emitSQL, methodArgs, allowed, shared)...)
+			out = append(out, walkTemplateList(st.Root, emitSQL, methodArgs, allowed, shared, taint, locals)...)
 		}
 		return out
 	case *parse.BreakNode, *parse.ContinueNode:
@@ -75,6 +87,115 @@ func walkTemplateNode(n parse.Node, emitSQL bool, methodArgs map[string]struct{}
 	default:
 		return nil
 	}
+}
+
+func copyVarTaint(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func addDeclTaints(p *parse.PipeNode, methodArgs map[string]struct{}, varTaint map[string]string) {
+	prov := branchTaint(p, methodArgs)
+	if prov == "" {
+		return
+	}
+	for _, vn := range p.Decl {
+		if name, ok := varNameFromIdent(vn.Ident); ok {
+			varTaint[name] = prov
+		}
+	}
+}
+
+func applyRangeDeclTaints(p *parse.PipeNode, prov string, methodArgs map[string]struct{}, varTaint map[string]string) {
+	if p == nil || prov == "" || len(p.Decl) == 0 {
+		return
+	}
+	decls := p.Decl
+	if len(decls) == 1 {
+		if name, ok := varNameFromIdent(decls[0].Ident); ok {
+			varTaint[name] = prov
+		}
+		return
+	}
+	if len(decls) == 2 {
+		if name, ok := varNameFromIdent(decls[1].Ident); ok {
+			varTaint[name] = prov
+		}
+	}
+}
+
+func vnameFromVariable(n *parse.VariableNode) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	if len(n.Ident) >= 2 && n.Ident[0] == "$" && n.Ident[1] != "" {
+		return n.Ident[1], true
+	}
+	if len(n.Ident) == 1 {
+		s := n.Ident[0]
+		if len(s) > 1 && s[0] == '$' {
+			return s[1:], true
+		}
+	}
+	return "", false
+}
+
+func varNameFromIdent(id []string) (string, bool) {
+	if len(id) < 2 || id[0] != "$" {
+		if len(id) == 1 && len(id[0]) > 0 {
+			s := id[0]
+			if s[0] == '$' && len(s) > 1 {
+				return s[1:], true
+			}
+		}
+		return "", false
+	}
+	if id[1] == "" {
+		return "", false
+	}
+	return id[1], true
+}
+
+func branchTaint(p *parse.PipeNode, methodArgs map[string]struct{}) string {
+	if p == nil {
+		return ""
+	}
+	for _, c := range p.Cmds {
+		for _, a := range c.Args {
+			if s := firstMethodArgRefInExpr(a, methodArgs); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func firstMethodArgRefInExpr(n parse.Node, methodArgs map[string]struct{}) string {
+	switch n := n.(type) {
+	case *parse.FieldNode:
+		if len(n.Ident) > 0 {
+			if _, ok := methodArgs[n.Ident[0]]; ok {
+				return n.Ident[0]
+			}
+		}
+	case *parse.VariableNode:
+		if v, ok := vnameFromVariable(n); ok {
+			if _, in := methodArgs[v]; in {
+				return v
+			}
+		}
+	case *parse.ChainNode:
+		return firstMethodArgRefInExpr(n.Node, methodArgs)
+	case *parse.PipeNode:
+		return branchTaint(n, methodArgs)
+	}
+	return ""
 }
 
 func lineOf(n parse.Node) int {
@@ -100,7 +221,7 @@ func lineOfPipe(p *parse.PipeNode) int {
 	return 0
 }
 
-func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int) []UnsafeInterpFinding {
+func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int, taint string, varTaint map[string]string) []UnsafeInterpFinding {
 	if pipe == nil {
 		return nil
 	}
@@ -108,7 +229,7 @@ func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]
 		var out []UnsafeInterpFinding
 		for _, cmd := range pipe.Cmds {
 			for _, arg := range cmd.Args {
-				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared)...)
+				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared, taint, varTaint)...)
 			}
 		}
 		return out
@@ -117,7 +238,7 @@ func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]
 		var out []UnsafeInterpFinding
 		for _, cmd := range pipe.Cmds {
 			for _, arg := range cmd.Args {
-				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared)...)
+				out = append(out, walkTemplateNode(arg, false, methodArgs, allowed, shared, taint, varTaint)...)
 			}
 		}
 		return out
@@ -132,7 +253,7 @@ func findPipeFindings(pipe *parse.PipeNode, emitSQL bool, methodArgs map[string]
 	var out []UnsafeInterpFinding
 	for _, cmd := range pipe.Cmds {
 		for _, arg := range cmd.Args {
-			out = append(out, scanArgForRawInterpolation(arg, methodArgs, allowed, shared, ln)...)
+			out = append(out, scanArgForRawInterpolation(arg, methodArgs, allowed, shared, ln, taint, varTaint)...)
 		}
 	}
 	return out
@@ -154,47 +275,64 @@ func pipeAllowedSink(pipe *parse.PipeNode, allowed map[string]struct{}) bool {
 	return ok
 }
 
-func scanArgForRawInterpolation(n parse.Node, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int) []UnsafeInterpFinding {
+func scanArgForRawInterpolation(n parse.Node, methodArgs map[string]struct{}, allowed map[string]struct{}, shared map[string]*parse.Tree, line int, taint string, varTaint map[string]string) []UnsafeInterpFinding {
 	switch n := n.(type) {
 	case *parse.FieldNode:
 		if len(n.Ident) == 0 {
 			return nil
 		}
-		if _, ok := methodArgs[n.Ident[0]]; !ok {
-			return nil
+		if _, ok := methodArgs[n.Ident[0]]; ok {
+			return []UnsafeInterpFinding{{MethodArg: n.Ident[0], Line: line, NodeSource: strings.TrimSpace(n.String())}}
 		}
-		return []UnsafeInterpFinding{{MethodArg: n.Ident[0], Line: line, NodeSource: strings.TrimSpace(n.String())}}
+		if taint != "" {
+			return []UnsafeInterpFinding{{MethodArg: taint, Line: line, NodeSource: strings.TrimSpace(n.String())}}
+		}
+		return nil
 	case *parse.VariableNode:
-		if len(n.Ident) >= 2 && n.Ident[0] == "$" {
-			if _, ok := methodArgs[n.Ident[1]]; ok {
-				return []UnsafeInterpFinding{{MethodArg: n.Ident[1], Line: line, NodeSource: strings.TrimSpace(n.String())}}
+		if vname, ok := vnameFromVariable(n); ok {
+			if prov, ok := varTaint[vname]; ok && prov != "" {
+				return []UnsafeInterpFinding{{MethodArg: prov, Line: line, NodeSource: strings.TrimSpace(n.String())}}
+			}
+			if _, ok := methodArgs[vname]; ok {
+				return []UnsafeInterpFinding{{MethodArg: vname, Line: line, NodeSource: strings.TrimSpace(n.String())}}
 			}
 		}
 		return nil
 	case *parse.DotNode:
+		if taint != "" {
+			return []UnsafeInterpFinding{{MethodArg: taint, Line: line, NodeSource: n.String()}}
+		}
 		return []UnsafeInterpFinding{{MethodArg: ".", Line: line, NodeSource: n.String()}}
 	case *parse.ChainNode:
-		return scanChainMethodArg(n, methodArgs, line)
+		return scanChainForRaw(n, methodArgs, line, taint, varTaint)
 	case *parse.PipeNode:
-		return findPipeFindings(n, true, methodArgs, allowed, shared, line)
+		return findPipeFindings(n, true, methodArgs, allowed, shared, line, taint, varTaint)
 	default:
 		return nil
 	}
 }
 
-func scanChainMethodArg(c *parse.ChainNode, methodArgs map[string]struct{}, line int) []UnsafeInterpFinding {
+func scanChainForRaw(c *parse.ChainNode, methodArgs map[string]struct{}, line int, taint string, varTaint map[string]string) []UnsafeInterpFinding {
 	switch r := c.Node.(type) {
 	case *parse.DotNode:
 		if len(c.Field) > 0 {
 			if _, ok := methodArgs[c.Field[0]]; ok {
 				return []UnsafeInterpFinding{{MethodArg: c.Field[0], Line: line, NodeSource: strings.TrimSpace(c.String())}}
 			}
+			if taint != "" {
+				return []UnsafeInterpFinding{{MethodArg: taint, Line: line, NodeSource: strings.TrimSpace(c.String())}}
+			}
 		}
 	case *parse.VariableNode:
-		if len(r.Ident) >= 2 && r.Ident[0] == "$" {
-			if _, ok := methodArgs[r.Ident[1]]; ok {
-				return []UnsafeInterpFinding{{MethodArg: r.Ident[1], Line: line, NodeSource: strings.TrimSpace(c.String())}}
-			}
+		vname, vok := vnameFromVariable(r)
+		if !vok {
+			return nil
+		}
+		if prov, ok := varTaint[vname]; ok && prov != "" {
+			return []UnsafeInterpFinding{{MethodArg: prov, Line: line, NodeSource: strings.TrimSpace(c.String())}}
+		}
+		if _, ok := methodArgs[vname]; ok {
+			return []UnsafeInterpFinding{{MethodArg: vname, Line: line, NodeSource: strings.TrimSpace(c.String())}}
 		}
 	}
 	return nil
@@ -328,7 +466,7 @@ func (ctx *sqlxContext) emitSqlxUnsafeInterpolationWarnings() {
 			continue
 		}
 		opts := method.SqlxOptions()
-		if hasOption(opts, "CONST") || hasOption(opts, "CONSTBIND") || hasOption(opts, "BIND") || hasOption(opts, "NAMED") {
+		if hasOption(opts, "CONST") || hasOption(opts, "CONSTBIND") {
 			continue
 		}
 		body, err := readHeader(method.Header, ctx.Pwd)
@@ -351,7 +489,11 @@ func (ctx *sqlxContext) emitSqlxUnsafeInterpolationWarnings() {
 				atLoc = fmt.Sprintf("%s:%d", ctx.File, f.Line)
 			}
 			fmt.Fprintf(os.Stderr, "defc: warning: method %s at %s interpolates argument %q as raw SQL text outside bind/bindvars.\n", method.Ident, atLoc, arg)
-			fmt.Fprintf(os.Stderr, "  This pattern is a SQL-injection foot-gun at runtime. Use {{ bind $.%s }} (requires the `bind` option), CONSTBIND with ${%s}, or positional ? placeholders instead.\n", arg, arg)
+			if arg == "." {
+				fmt.Fprintf(os.Stderr, "  This pattern is a SQL-injection foot-gun at runtime. Use {{ bind . }} if the intent is to bind the dot value, CONSTBIND where applicable, or positional ? placeholders instead.\n")
+			} else {
+				fmt.Fprintf(os.Stderr, "  This pattern is a SQL-injection foot-gun at runtime. Use {{ bind $.%s }} (requires the `bind` option), CONSTBIND with ${%s}, or positional ? placeholders instead.\n", arg, arg)
+			}
 			fmt.Fprintf(os.Stderr, "  Raw interpolation: %s\n", f.NodeSource)
 			fmt.Fprintf(os.Stderr, "  See https://github.com/x5iu/defc/issues/17 for guidance.\n")
 		}

--- a/gen/unsafe_interp_test.go
+++ b/gen/unsafe_interp_test.go
@@ -61,7 +61,7 @@ func TestScanUnsafeRawInterpolation_rangeBind(t *testing.T) {
 func TestScanUnsafeRawInterpolation_rangeDot(t *testing.T) {
 	tree := parseMust(t, "m", "{{range .xs}}{{ . }}{{end}}", nil)
 	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"xs": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
-	if len(findings) != 1 || findings[0].MethodArg != "." {
+	if len(findings) != 1 || findings[0].MethodArg != "xs" {
 		t.Fatalf("got %#v", findings)
 	}
 }
@@ -107,6 +107,46 @@ func TestParseInvalidTemplateNoPanic(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "error") && !strings.Contains(err.Error(), "unclosed") {
 		t.Logf("err: %v", err)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_withField(t *testing.T) {
+	tree := parseMust(t, "m", "{{ with .user }}{{ .Name }}{{ end }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"user": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "user" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_rangeUserField(t *testing.T) {
+	tree := parseMust(t, "m", "{{ range .users }}{{ .Name }}{{ end }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"users": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "users" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_rangeBindLocal(t *testing.T) {
+	tree := parseMust(t, "m", "{{ range $e := .list }}{{ $e }}{{ end }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"list": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "list" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_withBindOther(t *testing.T) {
+	tree := parseMust(t, "m", "{{ with .user }}{{ bind $.other }}{{ end }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"user": {}, "other": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 0 {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_mixedBindAndRaw(t *testing.T) {
+	tree := parseMust(t, "m", "SELECT * FROM t WHERE id = {{ bind $.id }} AND r = {{ .role }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"id": {}, "role": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "role" {
+		t.Fatalf("got %#v", findings)
 	}
 }
 

--- a/gen/unsafe_interp_test.go
+++ b/gen/unsafe_interp_test.go
@@ -1,0 +1,130 @@
+package gen
+
+import (
+	"strings"
+	"testing"
+	"text/template/parse"
+)
+
+func stubFuncs(extra map[string]any) map[string]any {
+	fm := map[string]any{
+		"bind":     func(...any) any { return "" },
+		"bindvars": func(...any) any { return "" },
+	}
+	for k, v := range extra {
+		fm[k] = v
+	}
+	return fm
+}
+
+func parseMust(t *testing.T, name, text string, extra map[string]any) *parse.Tree {
+	t.Helper()
+	trees, err := parse.Parse(name, text, "{{", "}}", stubFuncs(extra))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return trees[name]
+}
+
+func TestScanUnsafeRawInterpolation_field(t *testing.T) {
+	tree := parseMust(t, "m", "SELECT * FROM t WHERE x = {{ .name }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"name": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "name" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_bindSafe(t *testing.T) {
+	tree := parseMust(t, "m", "SELECT * FROM t WHERE x = {{ bind $.name }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"name": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 0 {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_ifGuard(t *testing.T) {
+	tree := parseMust(t, "m", "{{if .cond}}SELECT 1{{end}}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"cond": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 0 {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_rangeBind(t *testing.T) {
+	tree := parseMust(t, "m", "{{range .xs}}{{ bind . }}{{end}}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"xs": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 0 {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_rangeDot(t *testing.T) {
+	tree := parseMust(t, "m", "{{range .xs}}{{ . }}{{end}}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"xs": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "." {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_dollarField(t *testing.T) {
+	tree := parseMust(t, "m", "ORDER BY {{ $.table }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"table": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "table" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_userFuncNotSafe(t *testing.T) {
+	tree := parseMust(t, "m", "SELECT {{ myFunc .x }}", map[string]any{"myFunc": func(...any) any { return "" }})
+	findings := scanUnsafeRawInterpolation(tree, nil, map[string]struct{}{"x": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 1 || findings[0].MethodArg != "x" {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestScanUnsafeRawInterpolation_sharedTemplateNoMethodArg(t *testing.T) {
+	shared := `{{ define "audit" }}/* ok */{{ end }}`
+	sharedTrees, err := parse.Parse("shared", shared, "{{", "}}", stubFuncs(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := parseMust(t, "m", "{{ template \"audit\" . }}", nil)
+	findings := scanUnsafeRawInterpolation(tree, sharedTrees, map[string]struct{}{"ctx": {}}, map[string]struct{}{"bind": {}, "bindvars": {}})
+	if len(findings) != 0 {
+		t.Fatalf("got %#v", findings)
+	}
+}
+
+func TestParseInvalidTemplateNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic: %v", r)
+		}
+	}()
+	_, err := parse.Parse("bad", "{{ .x }", "{{", "}}", stubFuncs(nil))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "error") && !strings.Contains(err.Error(), "unclosed") {
+		t.Logf("err: %v", err)
+	}
+}
+
+func TestTemplateForestReferencesBind(t *testing.T) {
+	ctx := &sqlxContext{}
+	trees, err := parse.Parse("root", `{{ define "a" }}{{ bind .x }}{{ end }}`, "{{", "}}", sqlxParseStubFuncs(ctx))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !templateForestReferencesBind(trees) {
+		t.Fatal("expected bind reference")
+	}
+	trees2, err := parse.Parse("root2", `{{ define "a" }}plain{{ end }}`, "{{", "}}", sqlxParseStubFuncs(ctx))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if templateForestReferencesBind(trees2) {
+		t.Fatal("unexpected bind")
+	}
+}
+


### PR DESCRIPTION
Closes #17

## Summary

This PR adds a **codegen-time warning** when a sqlx method's SQL template interpolates a method argument as **raw** text outside the allowed sinks `bind` / `bindvars`. Discussion context: issue #17.

This is the static-analysis half of the issue #17 response. It surfaces the unsafe pattern on the first `go generate` after upgrade, before the code ships. The companion PR `fix/issue-17-silent-drop-runtime-warning` handles the observability side at runtime.

## What this PR is NOT

- **Not** a codegen error. Warnings go to stderr; `defc generate` still exits 0. Existing schemas continue to generate and compile.
- **Not** a lint over runtime-valid patterns. It only flags raw emission of method arguments that are not wrapped in `bind` / `bindvars`. Dynamic SQL identifiers like `ORDER BY {{ .col }}` will still warn (intentional — developers should validate `col` at their site and read the warning as a confirmation prompt).
- **Not** a breaking change to the binding hack. The previous `function "bind" not defined` string-match at `gen/sqlx.go` is replaced by an AST-based `bind` detection on the `--template` content; the original string fallback is retained for parse failures.

## Changes

- `gen/unsafe_interp.go` — new AST walker over `text/template/parse.Tree`, with dot-taint propagation through `{{ if }}` / `{{ range }}` / `{{ with }}` bodies, tracking variable declarations (`range $e := .xs`) and chain access (`.user.Name`). `bind` / `bindvars` are the only allowlisted sinks; user `--func` helpers are NOT implicitly trusted.
- `gen/sqlx.go` — call the walker after method parsing, emit a structured warning per finding to stderr including method name, file:line, offending action source, and a remediation suggestion. Replace the `"function \"bind\" not defined"` string-match hack with an AST walk over `ctx.Template` (with fallback to the old string match only if parse itself fails). Set `ctx.Pwd` from `builder.pwd` so `readHeader` sees the correct working directory for `#INCLUDE` / `#SCRIPT`.
- `gen/unsafe_interp_test.go` — unit tests covering:
  - raw `{{ .name }}` in default mode → 1 finding;
  - `{{ bind $.name }}` → 0 findings;
  - guard `{{ if .cond }}` → 0 findings;
  - `{{ range .xs }}{{ bind . }}{{ end }}` → 0 findings;
  - `{{ range .xs }}{{ . }}{{ end }}` → flagged on the inner action;
  - `{{ with .user }}{{ .Name }}{{ end }}` → flagged via dot provenance;
  - `{{ range $e := .users }}{{ $e.Name }}{{ end }}` → flagged via tainted declaration;
  - mixed BIND method with one raw field → flagged (this was the BLOCKER 2.1 Codex caught);
  - `{{ myFunc .x }}` (user `--func`) → still flagged;
  - parse error → error, not panic.
- `gen/integration/codegen_warn_test.go` — end-to-end capture of stderr from `defc generate` confirming the warning and the `exit 0`.
- `README.md` — new "SQL values: bind, don't interpolate" subsection with the PoC exploit and three safe alternatives (`?`, `CONSTBIND ${x}`, `{{ bind $.x }}`).
- `CHANGELOG.md` — new entry under Added.

## Test evidence

```
+ go test -cover ./gen
ok  	github.com/x5iu/defc/gen	1.050s	coverage: 85.1% of statements
+ go test -cover ./runtime
ok  	github.com/x5iu/defc/runtime	(cached)	coverage: 90.8% of statements
+ go test -cover ./sqlx
ok  	github.com/x5iu/defc/sqlx	(cached)	coverage: 3.4% of statements
+ go test -tags=test ./gen/integration
ok  	github.com/x5iu/defc/gen/integration	1.436s
```

## Breaking changes

None. The warning is stderr-only, codegen still succeeds.

## Migration

Run `go generate` (or `defc generate`) after upgrading. Any warnings indicate places where the schema author should either switch to `{{ bind $.x }}` / `CONSTBIND ${x}` / `?` (for values) or confirm independent identifier validation (for dynamic `ORDER BY` / table / column).

## Known limitations / follow-ups

- **Taint through local aliases is minimal**: `{{ range $e := .users }}{{ $e.Name }}{{ end }}` is flagged, but more complex propagation (`{{ $x := .y.z }}` outside a `with` / `range`) may still miss. Documented on `scanUnsafeRawInterpolation`.
- **`file:line` reports the line within the parsed SQL fragment** once `ctx.File` is set — not the original Go source line (comment offsets, `#INCLUDE`, `#SCRIPT` shift things). Resolving that cleanly is a follow-up.

See #17 for the full multi-perspective discussion that led to this framing (`safe-by-default hardening via visibility`, not a security fix).
