### PR TITLE
🐛 Fix API header CRLF injection

### DIFF
--- a/gen/api.go
+++ b/gen/api.go
@@ -133,6 +133,27 @@ func (ctx *apiContext) Build(w io.Writer) error {
 		return fmt.Errorf("api/gzip feature requires api/nort feature to be disabled")
 	}
 
+	for _, method := range ctx.Methods {
+		if method.Header == "" {
+			continue
+		}
+		fields, bodyTmpl, err := parseApiHeaderSpec(method.Header)
+		if err != nil {
+			return fmt.Errorf("method %s: %w", quote(method.Ident), err)
+		}
+		if len(fields) == 0 && bodyTmpl == "" {
+			return fmt.Errorf("method %s: API header block is empty", quote(method.Ident))
+		}
+		if bodyTmpl != "" && !httpMethodHasBody(method.MethodHTTP()) {
+			return fmt.Errorf(
+				"method %s: request body in API header block is only allowed for POST, PUT, or PATCH",
+				quote(method.Ident),
+			)
+		}
+		method.ApiHeaderFields = fields
+		method.ApiBodyTemplate = bodyTmpl
+	}
+
 	if err := ctx.genApiCode(w); err != nil {
 		return fmt.Errorf("genApiCode: %w", err)
 	}
@@ -183,18 +204,18 @@ func (ctx *apiContext) HasFeature(feature string) bool {
 	return false
 }
 
-func (ctx *apiContext) HasHeader() bool {
+func (ctx *apiContext) HasBody() bool {
 	for _, method := range ctx.Methods {
-		if method.Header != "" {
+		if httpMethodHasBody(method.MethodHTTP()) && method.ApiBodyTemplate != "" {
 			return true
 		}
 	}
 	return false
 }
 
-func (ctx *apiContext) HasBody() bool {
+func (ctx *apiContext) hasAnyApiHeaderFields() bool {
 	for _, method := range ctx.Methods {
-		if httpMethodHasBody(method.MethodHTTP()) && headerHasBody(method.TmplHeader()) {
+		if len(method.ApiHeaderFields) > 0 {
 			return true
 		}
 	}
@@ -254,12 +275,12 @@ func (ctx *apiContext) MergedImports() (imports []string) {
 		imports = append(imports, parseImport("__rt github.com/x5iu/defc/runtime"))
 	}
 
-	if ctx.HasHeader() {
-		imports = append(imports, quote("bufio"))
-		imports = append(imports, quote("net/textproto"))
-		if ctx.HasBody() && ctx.HasFeature(FeatureApiLogx) {
-			imports = append(imports, quote("bytes"))
-		}
+	if ctx.hasAnyApiHeaderFields() {
+		imports = append(imports, quote("strings"))
+	}
+
+	if ctx.HasBody() && !ctx.HasFeature(FeatureApiNoRt) {
+		imports = append(imports, quote("bytes"))
 	}
 
 	if importContext(ctx.Methods) {
@@ -434,14 +455,8 @@ func httpMethodHasBody(method string) bool {
 	}
 }
 
-func headerHasBody(header string) bool {
-	if idx := index(header, "\r\n\r\n"); idx != -1 {
-		return len(trimSpace(header[idx+4:])) > 0
-	}
-	if idx := index(header, "\n\n"); idx != -1 {
-		return len(trimSpace(header[idx+2:])) > 0
-	}
-	return false
+func apiHeaderSpecProvidesBody(method *Method) bool {
+	return method.ApiBodyTemplate != ""
 }
 
 //go:embed template/api.tmpl
@@ -462,8 +477,8 @@ func (ctx *apiContext) genApiCode(w io.Writer) error {
 			"methodInner":       ctx.MethodInner,
 			"isResponse":        isResponse,
 			"isInner":           isInner,
-			"httpMethodHasBody": httpMethodHasBody,
-			"headerHasBody":     headerHasBody,
+			"httpMethodHasBody":        httpMethodHasBody,
+			"apiHeaderSpecProvidesBody": apiHeaderSpecProvidesBody,
 		}).
 		Parse(apiTemplate)
 

--- a/gen/api.go
+++ b/gen/api.go
@@ -466,18 +466,18 @@ func (ctx *apiContext) genApiCode(w io.Writer) error {
 	tmpl, err := template.
 		New("defc(api)").
 		Funcs(template.FuncMap{
-			"quote":             quote,
-			"isPointer":         isPointer,
-			"indirect":          indirect,
-			"importContext":     importContext,
-			"sub":               func(x, y int) int { return x - y },
-			"getRepr":           func(node ast.Node) string { return ctx.Doc.Repr(node) },
-			"isEllipsis":        func(node ast.Node) bool { return hasPrefix(ctx.Doc.Repr(node), "...") },
-			"methodResp":        ctx.MethodResponse,
-			"methodInner":       ctx.MethodInner,
-			"isResponse":        isResponse,
-			"isInner":           isInner,
-			"httpMethodHasBody":        httpMethodHasBody,
+			"quote":                     quote,
+			"isPointer":                 isPointer,
+			"indirect":                  indirect,
+			"importContext":             importContext,
+			"sub":                       func(x, y int) int { return x - y },
+			"getRepr":                   func(node ast.Node) string { return ctx.Doc.Repr(node) },
+			"isEllipsis":                func(node ast.Node) bool { return hasPrefix(ctx.Doc.Repr(node), "...") },
+			"methodResp":                ctx.MethodResponse,
+			"methodInner":               ctx.MethodInner,
+			"isResponse":                isResponse,
+			"isInner":                   isInner,
+			"httpMethodHasBody":         httpMethodHasBody,
 			"apiHeaderSpecProvidesBody": apiHeaderSpecProvidesBody,
 		}).
 		Parse(apiTemplate)

--- a/gen/api.go
+++ b/gen/api.go
@@ -213,15 +213,6 @@ func (ctx *apiContext) HasBody() bool {
 	return false
 }
 
-func (ctx *apiContext) hasAnyApiHeaderFields() bool {
-	for _, method := range ctx.Methods {
-		if len(method.ApiHeaderFields) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func (ctx *apiContext) HasInner() bool {
 	return hasInner(ctx.Methods)
 }
@@ -275,7 +266,7 @@ func (ctx *apiContext) MergedImports() (imports []string) {
 		imports = append(imports, parseImport("__rt github.com/x5iu/defc/runtime"))
 	}
 
-	if ctx.hasAnyApiHeaderFields() {
+	if ctx.HasFeature(FeatureApiGzip) {
 		imports = append(imports, quote("strings"))
 	}
 

--- a/gen/api_header_parse_test.go
+++ b/gen/api_header_parse_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+func TestSplitApiHeaderAndBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantHeader string
+		wantBody   string
+	}{
+		{"crlfcrlf_separator", "A: 1\r\n\r\nBODY", "A: 1", "BODY"},
+		{"lf_separator", "A: 1\n\nBODY", "A: 1", "BODY"},
+		{"no_separator", "A: 1\r\n", "A: 1", ""},
+		{"whitespace_only", "   \t\r\n", "", ""},
+		{"crlf_takes_precedence_over_lf", "A: 1\r\n\r\nB1\n\nB2", "A: 1", "B1\n\nB2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotH, gotB := splitApiHeaderAndBody(tt.raw)
+			if gotH != tt.wantHeader || gotB != tt.wantBody {
+				t.Fatalf("splitApiHeaderAndBody(%q) = (%q, %q) want (%q, %q)", tt.raw, gotH, gotB, tt.wantHeader, tt.wantBody)
+			}
+		})
+	}
+}
+
 func TestParseApiHeaderSpec(t *testing.T) {
 	t.Run("header_only", func(t *testing.T) {
 		fields, body, err := parseApiHeaderSpec("Content-Type: application/json\r\n\r\n")
@@ -69,6 +92,24 @@ func TestParseApiHeaderSpec(t *testing.T) {
 		_, _, err := parseApiHeaderSpec("nocolon line\r\n\r\n")
 		if err == nil || !strings.Contains(err.Error(), "':'") {
 			t.Fatalf("got %v", err)
+		}
+	})
+	t.Run("lf_only_separator", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("X-A: 1\n\n{{ .b }}")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 1 || fields[0].Name != "X-A" || fields[0].Value != "1" || body != "{{ .b }}" {
+			t.Fatalf("got %+v body=%q", fields, body)
+		}
+	})
+	t.Run("empty_header_block_returns_no_fields", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("   ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 0 || body != "" {
+			t.Fatalf("got %+v body=%q err=%v", fields, body, err)
 		}
 	})
 }

--- a/gen/api_header_parse_test.go
+++ b/gen/api_header_parse_test.go
@@ -17,6 +17,8 @@ func TestSplitApiHeaderAndBody(t *testing.T) {
 		{"no_separator", "A: 1\r\n", "A: 1", ""},
 		{"whitespace_only", "   \t\r\n", "", ""},
 		{"crlf_takes_precedence_over_lf", "A: 1\r\n\r\nB1\n\nB2", "A: 1", "B1\n\nB2"},
+		{"body_only_crlf", "\r\n\r\n{{ .b }}", "", "{{ .b }}"},
+		{"body_only_lf", "\n\n{{ .b }}", "", "{{ .b }}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -110,6 +112,33 @@ func TestParseApiHeaderSpec(t *testing.T) {
 		}
 		if len(fields) != 0 || body != "" {
 			t.Fatalf("got %+v body=%q err=%v", fields, body, err)
+		}
+	})
+	t.Run("body_only_crlf_separator", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("\r\n\r\n{{ .body }}")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 0 || body != "{{ .body }}" {
+			t.Fatalf("got %+v body=%q", fields, body)
+		}
+	})
+	t.Run("body_only_lf_separator", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("\n\n{{ .body }}")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 0 || body != "{{ .body }}" {
+			t.Fatalf("got %+v body=%q", fields, body)
+		}
+	})
+	t.Run("crlf_separator_empty_body", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("\r\n\r\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 0 || body != "" {
+			t.Fatalf("got %+v body=%q", fields, body)
 		}
 	})
 }

--- a/gen/api_header_parse_test.go
+++ b/gen/api_header_parse_test.go
@@ -1,0 +1,74 @@
+package gen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseApiHeaderSpec(t *testing.T) {
+	t.Run("header_only", func(t *testing.T) {
+		fields, body, err := parseApiHeaderSpec("Content-Type: application/json\r\n\r\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body != "" || len(fields) != 1 || fields[0].Name != "Content-Type" || fields[0].Value != "application/json" {
+			t.Fatalf("got %+v body=%q", fields, body)
+		}
+	})
+	t.Run("header_and_body", func(t *testing.T) {
+		raw := "X-A: 1\r\n\r\n{{ .b }}\r\n"
+		fields, body, err := parseApiHeaderSpec(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 1 || fields[0].Name != "X-A" || fields[0].Value != "1" || body != "{{ .b }}" {
+			t.Fatalf("got %+v body=%q", fields, body)
+		}
+	})
+	t.Run("repeated_keys", func(t *testing.T) {
+		raw := "Set-Cookie: a=b\r\nSet-Cookie: c=d\r\n\r\n"
+		fields, body, err := parseApiHeaderSpec(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body != "" || len(fields) != 2 || fields[0].Name != "Set-Cookie" || fields[1].Name != "Set-Cookie" {
+			t.Fatalf("got %+v", fields)
+		}
+	})
+	t.Run("value_colon", func(t *testing.T) {
+		fields, _, err := parseApiHeaderSpec("Authorization: Bearer a:b:c\r\n\r\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 1 || fields[0].Value != "Bearer a:b:c" {
+			t.Fatalf("got %+v", fields)
+		}
+	})
+	t.Run("minus_prefix", func(t *testing.T) {
+		fields, _, err := parseApiHeaderSpec("- X-Custom: z\r\n\r\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fields) != 1 || fields[0].Name != "X-Custom" || fields[0].Value != "z" {
+			t.Fatalf("got %+v", fields)
+		}
+	})
+	t.Run("reject_dynamic_key", func(t *testing.T) {
+		_, _, err := parseApiHeaderSpec("{{ .k }}: v\r\n\r\n")
+		if err == nil || !strings.Contains(err.Error(), "static") {
+			t.Fatalf("want static key error, got %v", err)
+		}
+	})
+	t.Run("reject_invalid_key_space", func(t *testing.T) {
+		_, _, err := parseApiHeaderSpec("Bad Name: x\r\n\r\n")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("reject_no_colon", func(t *testing.T) {
+		_, _, err := parseApiHeaderSpec("nocolon line\r\n\r\n")
+		if err == nil || !strings.Contains(err.Error(), "':'") {
+			t.Fatalf("got %v", err)
+		}
+	})
+}

--- a/gen/api_test.go
+++ b/gen/api_test.go
@@ -245,6 +245,55 @@ func TestBuildApi(t *testing.T) {
 			return
 		}
 	})
+	t.Run("fail_header_empty_block", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		if err := runTest(genFile, builder); err == nil {
+			t.Errorf("build: expects errors, got nil")
+			return
+		} else if !strings.Contains(err.Error(), "API header block is empty") || !strings.Contains(err.Error(), `"Run"`) {
+			t.Errorf("build: expects empty API header error for Run, got => %s", err)
+			return
+		}
+	})
+	t.Run("fail_body_template_get", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		if err := runTest(genFile, builder); err == nil {
+			t.Errorf("build: expects errors, got nil")
+			return
+		} else if !strings.Contains(err.Error(), "only allowed for POST, PUT, or PATCH") || !strings.Contains(err.Error(), `"Run"`) {
+			t.Errorf("build: expects body-on-GET error, got => %s", err)
+			return
+		}
+	})
+	t.Run("fail_body_template_head", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		if err := runTest(genFile, builder); err == nil {
+			t.Errorf("build: expects errors, got nil")
+			return
+		} else if !strings.Contains(err.Error(), "only allowed for POST, PUT, or PATCH") || !strings.Contains(err.Error(), `"Run"`) {
+			t.Errorf("build: expects body-on-HEAD error, got => %s", err)
+			return
+		}
+	})
+	t.Run("success_body_template_post", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		if err := runTest(genFile, builder); err != nil {
+			t.Errorf("build: %s", err)
+			return
+		}
+	})
 }
 
 func TestGenApiOutputHasNoMIMEParsing(t *testing.T) {

--- a/gen/api_test.go
+++ b/gen/api_test.go
@@ -246,3 +246,59 @@ func TestBuildApi(t *testing.T) {
 		}
 	})
 }
+
+func TestGenApiOutputHasNoMIMEParsing(t *testing.T) {
+	const (
+		testPk = "test"
+		testGo = testPk + ".go"
+	)
+	testDir := filepath.Join("testdata", "api")
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(pwd) }()
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := os.ReadFile(testGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pos int
+	lineScanner := bufio.NewScanner(bytes.NewReader(doc))
+	for i := 1; lineScanner.Scan(); i++ {
+		text := lineScanner.Text()
+		if strings.HasPrefix(text, "//go:generate") &&
+			strings.HasSuffix(text, "TestBuildApi/success") {
+			pos = i
+			break
+		}
+	}
+	if err := lineScanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if pos == 0 {
+		t.Fatal("pos not found")
+	}
+	testDirAbs, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder := NewCliBuilder(ModeApi).
+		WithFeats([]string{FeatureApiNoRt, FeatureApiFuture}).
+		WithPkg(testPk).
+		WithPwd(testDirAbs).
+		WithFile(testGo, doc).
+		WithPos(pos)
+	var buf bytes.Buffer
+	if err := builder.Build(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, sub := range []string{"bufio", "net/textproto", "ReadMIMEHeader"} {
+		if strings.Contains(out, sub) {
+			t.Errorf("generated code must not contain %q", sub)
+		}
+	}
+}

--- a/gen/api_test.go
+++ b/gen/api_test.go
@@ -304,6 +304,17 @@ func TestBuildApi(t *testing.T) {
 			return
 		}
 	})
+	t.Run("success_gzip_no_headers", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		builder = builder.WithFeats([]string{FeatureApiFuture, FeatureApiGzip})
+		if err := runTest(genFile, builder); err != nil {
+			t.Errorf("build: %s", err)
+			return
+		}
+	})
 }
 
 func TestGenApiOutputHasNoMIMEParsing(t *testing.T) {
@@ -358,6 +369,120 @@ func TestGenApiOutputHasNoMIMEParsing(t *testing.T) {
 	for _, sub := range []string{"bufio", "net/textproto", "ReadMIMEHeader"} {
 		if strings.Contains(out, sub) {
 			t.Errorf("generated code must not contain %q", sub)
+		}
+	}
+}
+
+func TestApiGzipNoHeadersEmitsStringsImport(t *testing.T) {
+	const (
+		testPk = "test"
+		testGo = testPk + ".go"
+	)
+	testDir := filepath.Join("testdata", "api")
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(pwd) }()
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := os.ReadFile(testGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pos int
+	lineScanner := bufio.NewScanner(bytes.NewReader(doc))
+	for i := 1; lineScanner.Scan(); i++ {
+		text := lineScanner.Text()
+		if strings.HasPrefix(text, "//go:generate") &&
+			strings.HasSuffix(text, "TestBuildApi/success_gzip_no_headers") {
+			pos = i
+			break
+		}
+	}
+	if err = lineScanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if pos == 0 {
+		t.Fatal("pos not found")
+	}
+	testDirAbs, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err = NewCliBuilder(ModeApi).
+		WithFeats([]string{FeatureApiFuture, FeatureApiGzip}).
+		WithPkg(testPk).
+		WithPwd(testDirAbs).
+		WithFile(testGo, doc).
+		WithPos(pos).
+		Build(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"strings"`) {
+		t.Fatalf("api/gzip without custom headers: generated code must import strings, got snippet:\n%s", out)
+	}
+}
+
+func TestApiGeneratedCodeHeaderValueValidation(t *testing.T) {
+	const (
+		testPk = "test"
+		testGo = testPk + ".go"
+	)
+	testDir := filepath.Join("testdata", "api")
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(pwd) }()
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := os.ReadFile(testGo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pos int
+	lineScanner := bufio.NewScanner(bytes.NewReader(doc))
+	for i := 1; lineScanner.Scan(); i++ {
+		text := lineScanner.Text()
+		if strings.HasPrefix(text, "//go:generate") &&
+			strings.HasSuffix(text, "TestBuildApi/success") {
+			pos = i
+			break
+		}
+	}
+	if err = lineScanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if pos == 0 {
+		t.Fatal("pos not found")
+	}
+	testDirAbs, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err = NewCliBuilder(ModeApi).
+		WithFeats([]string{FeatureApiNoRt, FeatureApiFuture}).
+		WithPkg(testPk).
+		WithPwd(testDirAbs).
+		WithFile(testGo, doc).
+		WithPos(pos).
+		Build(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, s := range []string{
+		"contains disallowed control character 0x%02x",
+		"__c < 0x20 && __c != '\\t'",
+		"__c == 0x7f",
+	} {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected generated code to contain %q", s)
 		}
 	}
 }

--- a/gen/api_test.go
+++ b/gen/api_test.go
@@ -294,6 +294,16 @@ func TestBuildApi(t *testing.T) {
 			return
 		}
 	})
+	t.Run("success_body_only", func(t *testing.T) {
+		builder, ok := newBuilder(t)
+		if !ok {
+			return
+		}
+		if err := runTest(genFile, builder); err != nil {
+			t.Errorf("build: %s", err)
+			return
+		}
+	})
 }
 
 func TestGenApiOutputHasNoMIMEParsing(t *testing.T) {

--- a/gen/integration/api/main.go
+++ b/gen/integration/api/main.go
@@ -70,10 +70,31 @@ func main() {
 	if user.ID != 4 || user.Name != "defc_test_0004" {
 		log.Fatalf("unexpected user with MakeUpdateUserRequest: User(id=%d, name=%q)\n", user.ID, user.Name)
 	}
+	tr := client.Options().Client().Transport.(*Transport)
+	if _, err := client.MalHdr(ctx, "abc\r\nX-Evil: 1", strings.NewReader("PAYLOAD")); err == nil {
+		log.Fatalln("expected error for CRLF in header value")
+	}
+	if tr.malhdrRounds != 0 {
+		log.Fatalf("transport saw malhdr rounds=%d want 0", tr.malhdrRounds)
+	}
+	if _, err := client.MalHdr(ctx, "abc\r\n\r\n{\"evil\":true}", strings.NewReader("PAYLOAD")); err == nil {
+		log.Fatalln("expected error for CRLFCRLF in header value")
+	}
+	if _, err := client.MalHdr(ctx, "abc\x00", strings.NewReader("PAYLOAD")); err == nil {
+		log.Fatalln("expected error for NUL in header value")
+	}
+	user, err = client.MalHdr(ctx, "hello:世界", strings.NewReader(`{"k":1}`))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if user.ID != 99 || user.Name != "hdr_ok" {
+		log.Fatalf("unexpected MalHdr ok: %+v", user)
+	}
 }
 
 type Transport struct {
-	retryCount map[string]int
+	retryCount   map[string]int
+	malhdrRounds int
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -128,6 +149,35 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				Body:       io.NopCloser(bytes.NewBufferString(`{"code":200,"message":"","data":{"id":4,"name":"defc_test_0004"}}`)),
 			}, nil
 		}
+	case "/v1/malhdr":
+		if method != http.MethodPost {
+			panic("malhdr method")
+		}
+		t.malhdrRounds++
+		if req.Header.Get("X-Evil") != "" {
+			panic("X-Evil header must not be set")
+		}
+		tok := req.Header.Get("X-Token")
+		if tok == "" {
+			panic("missing X-Token")
+		}
+		if req.Body != nil {
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				panic(err)
+			}
+			req.Body.Close()
+			if string(b) != `{"k":1}` {
+				panic(fmt.Sprintf("malhdr body %q", b))
+			}
+		}
+		if tok != "hello:世界" {
+			panic(fmt.Sprintf("token %q", tok))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"code":200,"message":"","data":{"id":99,"name":"hdr_ok"}}`)),
+		}, nil
 	case "/v1/users/":
 		switch method {
 		case "POST":
@@ -221,6 +271,10 @@ type Client interface {
 	//
 	// {{ encodejson .req }}
 	MakeUpdateUserRequest(ctx context.Context, req *User) (*User, error)
+
+	// MalHdr POST https://localhost:443/v1/malhdr
+	// X-Token: {{ .tok }}
+	MalHdr(ctx context.Context, tok string, body io.Reader) (*User, error)
 }
 
 type User struct {

--- a/gen/integration/api/main.go
+++ b/gen/integration/api/main.go
@@ -81,6 +81,9 @@ func main() {
 		{"NUL", "abc\x00"},
 		{"CR_only", "abc\rX"},
 		{"LF_only", "abc\nX"},
+		{"SOH", "abc\x01"},
+		{"US", "abc\x1f"},
+		{"DEL", "abc\x7f"},
 	} {
 		if _, err := client.MalHdr(ctx, tc.tok, strings.NewReader("PAYLOAD")); err == nil {
 			log.Fatalf("%s: expected error", tc.name)
@@ -89,6 +92,17 @@ func main() {
 			log.Fatalf("%s: transport saw malhdr rounds=%d want %d", tc.name, tr.malhdrRounds, before)
 		}
 	}
+	user, err = client.MalHdr(ctx, "pre\tpost", strings.NewReader(`{"k":1}`))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if user.ID != 99 || user.Name != "hdr_ok" {
+		log.Fatalf("unexpected MalHdr tab: %+v", user)
+	}
+	if tr.malhdrRounds != before+1 {
+		log.Fatalf("transport saw malhdr rounds=%d want %d after tab MalHdr", tr.malhdrRounds, before+1)
+	}
+	before = tr.malhdrRounds
 	user, err = client.MalHdr(ctx, "hello:世界", strings.NewReader(`{"k":1}`))
 	if err != nil {
 		log.Fatalln(err)
@@ -180,7 +194,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				panic(fmt.Sprintf("malhdr body %q", b))
 			}
 		}
-		if tok != "hello:世界" {
+		if tok != "hello:世界" && tok != "pre\tpost" {
 			panic(fmt.Sprintf("token %q", tok))
 		}
 		return &http.Response{

--- a/gen/integration/api/main.go
+++ b/gen/integration/api/main.go
@@ -71,17 +71,23 @@ func main() {
 		log.Fatalf("unexpected user with MakeUpdateUserRequest: User(id=%d, name=%q)\n", user.ID, user.Name)
 	}
 	tr := client.Options().Client().Transport.(*Transport)
-	if _, err := client.MalHdr(ctx, "abc\r\nX-Evil: 1", strings.NewReader("PAYLOAD")); err == nil {
-		log.Fatalln("expected error for CRLF in header value")
-	}
-	if tr.malhdrRounds != 0 {
-		log.Fatalf("transport saw malhdr rounds=%d want 0", tr.malhdrRounds)
-	}
-	if _, err := client.MalHdr(ctx, "abc\r\n\r\n{\"evil\":true}", strings.NewReader("PAYLOAD")); err == nil {
-		log.Fatalln("expected error for CRLFCRLF in header value")
-	}
-	if _, err := client.MalHdr(ctx, "abc\x00", strings.NewReader("PAYLOAD")); err == nil {
-		log.Fatalln("expected error for NUL in header value")
+	before := tr.malhdrRounds
+	for _, tc := range []struct {
+		name string
+		tok  string
+	}{
+		{"CRLF", "abc\r\nX-Evil: 1"},
+		{"CRLFCRLF", "abc\r\n\r\n{\"evil\":true}"},
+		{"NUL", "abc\x00"},
+		{"CR_only", "abc\rX"},
+		{"LF_only", "abc\nX"},
+	} {
+		if _, err := client.MalHdr(ctx, tc.tok, strings.NewReader("PAYLOAD")); err == nil {
+			log.Fatalf("%s: expected error", tc.name)
+		}
+		if tr.malhdrRounds != before {
+			log.Fatalf("%s: transport saw malhdr rounds=%d want %d", tc.name, tr.malhdrRounds, before)
+		}
 	}
 	user, err = client.MalHdr(ctx, "hello:世界", strings.NewReader(`{"k":1}`))
 	if err != nil {
@@ -89,6 +95,9 @@ func main() {
 	}
 	if user.ID != 99 || user.Name != "hdr_ok" {
 		log.Fatalf("unexpected MalHdr ok: %+v", user)
+	}
+	if tr.malhdrRounds != before+1 {
+		log.Fatalf("transport saw malhdr rounds=%d want %d after valid MalHdr", tr.malhdrRounds, before+1)
 	}
 }
 

--- a/gen/method.go
+++ b/gen/method.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 // Method represents a method declaration in an interface
@@ -29,6 +30,14 @@ type Method struct {
 
 	// Source represents the raw file content
 	Source []byte
+
+	ApiHeaderFields []HeaderField
+	ApiBodyTemplate string
+}
+
+type HeaderField struct {
+	Name  string
+	Value string
 }
 
 func (method *Method) TxType() (ast.Expr, error) {
@@ -83,25 +92,65 @@ func (method *Method) TmplURL() string {
 
 var minusRe = regexp.MustCompile(`(?m)^[ \t]*?-[ \t]*`)
 
-// TmplHeader should only be used with '--mode=api' arg
-func (method *Method) TmplHeader() string {
-	var (
-		header = method.Header
-		body   string
-	)
-	if idx := index(header, "\r\n\r\n"); idx != -1 {
-		body = trimSpace(header[idx+4:])
-		header = trimSpace(header[:idx])
+func splitApiHeaderAndBody(raw string) (headerPart, bodyPart string) {
+	raw = strings.TrimSpace(raw)
+	if i := strings.Index(raw, "\r\n\r\n"); i >= 0 {
+		return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+4:])
 	}
-	if idx := index(header, "\n\n"); idx != -1 {
-		body = trimSpace(header[idx+2:])
-		header = trimSpace(header[:idx])
+	if i := strings.Index(raw, "\n\n"); i >= 0 {
+		return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+2:])
 	}
-	header = minusRe.ReplaceAllString(header, "") + "\r\n\r\n"
-	if len(body) > 0 {
-		header += body
+	return raw, ""
+}
+
+func isHTTPHeaderTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
 	}
-	return header
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return false
+}
+
+func validateStaticAPIHeaderName(key string) error {
+	if key == "" {
+		return fmt.Errorf("api header field name is empty")
+	}
+	if strings.Contains(key, "{{") || strings.Contains(key, "}}") {
+		return fmt.Errorf("api header field name %q must be static; use OPTIONS(opts) for dynamic headers", key)
+	}
+	for i := 0; i < len(key); i++ {
+		if !isHTTPHeaderTokenChar(key[i]) {
+			return fmt.Errorf("api header field name %q contains invalid byte %q", key, key[i:i+1])
+		}
+	}
+	return nil
+}
+
+func parseApiHeaderSpec(raw string) ([]HeaderField, string, error) {
+	headerText, bodyPart := splitApiHeaderAndBody(raw)
+	headerText = minusRe.ReplaceAllString(headerText, "")
+	var fields []HeaderField
+	for _, line := range strings.Split(headerText, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			return nil, "", fmt.Errorf("api header line has no ':' separator: %q", line)
+		}
+		key := strings.TrimSpace(line[:colon])
+		val := strings.TrimSpace(line[colon+1:])
+		if err := validateStaticAPIHeaderName(key); err != nil {
+			return nil, "", err
+		}
+		fields = append(fields, HeaderField{Name: key, Value: val})
+	}
+	return fields, bodyPart, nil
 }
 
 var availableMethods = []string{

--- a/gen/method.go
+++ b/gen/method.go
@@ -93,14 +93,15 @@ func (method *Method) TmplURL() string {
 var minusRe = regexp.MustCompile(`(?m)^[ \t]*?-[ \t]*`)
 
 func splitApiHeaderAndBody(raw string) (headerPart, bodyPart string) {
-	raw = strings.TrimSpace(raw)
 	if i := strings.Index(raw, "\r\n\r\n"); i >= 0 {
-		return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+4:])
+		if i+4 < len(raw) || i == 0 {
+			return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+4:])
+		}
 	}
 	if i := strings.Index(raw, "\n\n"); i >= 0 {
 		return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+2:])
 	}
-	return raw, ""
+	return strings.TrimSpace(raw), ""
 }
 
 func isHTTPHeaderTokenChar(c byte) bool {

--- a/gen/template/api.tmpl
+++ b/gen/template/api.tmpl
@@ -393,13 +393,16 @@ var (
         }
         {{ $hv := printf "hv%s_%d" $method.Ident $hi }}
         {{ $hv }} := {{ $header }}.String()
-        if strings.ContainsAny({{ $hv }}, "\r\n\x00") {
+        for __i := 0; __i < len({{ $hv }}); __i++ {
+        __c := {{ $hv }}[__i]
+        if (__c < 0x20 && __c != '\t') || __c == 0x7f {
         return {{ range $index, $type := $method.Out -}}
             {{- if lt $index (sub (len $method.Out) 1) -}}
                 v{{- $index -}}{{- $method.Ident }},
             {{- end -}}
         {{- end -}}
-        fmt.Errorf("invalid header value for %s: contains CR, LF, or NUL", {{ quote $hf.Name }})
+        fmt.Errorf("invalid header value for %s: contains disallowed control character 0x%02x", {{ quote $hf.Name }}, __c)
+        }
         }
         {{ $request }}.Header.Add({{ quote $hf.Name }}, {{ $hv }})
         {{ $header }}.Reset()

--- a/gen/template/api.tmpl
+++ b/gen/template/api.tmpl
@@ -35,8 +35,17 @@ type {{ $impName }}{{ $.GenericsRepr true }} struct{
 {{ $additionalFuncs := $.AdditionalFuncs }}
 var (
 {{ range $index, $method := $.Methods }} {{ if and (not (and $method.ReturnSlice ($.HasFeature "api/page"))) (not (isInner $method.Ident)) (not (isResponse $method.Ident)) }}
-    {{ printf "addr%sTmpl%s" $.Ident $method.Ident }} = template.Must(template.New("Address{{ $method.Ident }}"){{ if gt (len $additionalFuncs) 0 }}.Funcs(template.FuncMap{ {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }}, {{ end }} }){{ end }}.Parse({{ quote ($method.TmplURL) }})) {{ if ne $method.Header "" }}
-        {{ printf "header%sTmpl%s" $.Ident $method.Ident }} = template.Must(template.New("Header{{ $method.Ident }}"){{ if gt (len $additionalFuncs) 0 }}.Funcs(template.FuncMap{ {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }}, {{ end }} }){{ end }}.Parse({{ quote $method.TmplHeader }})) {{ end }} {{ end }} {{ end }}
+    {{ printf "addr%sTmpl%s" $.Ident $method.Ident }} = template.Must(template.New("Address{{ $method.Ident }}"){{ if gt (len $additionalFuncs) 0 }}.Funcs(template.FuncMap{ {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }}, {{ end }} }){{ end }}.Parse({{ quote ($method.TmplURL) }}))
+    {{ if or (gt (len $method.ApiHeaderFields) 0) (ne $method.ApiBodyTemplate "") }}
+    {{ range $hi, $hf := $method.ApiHeaderFields }}
+    {{ printf "header%sTmpl%s_%d" $.Ident $method.Ident $hi }} = template.Must(template.New("Header{{ $method.Ident }}_{{ $hi }}"){{ if gt (len $additionalFuncs) 0 }}.Funcs(template.FuncMap{ {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }}, {{ end }} }){{ end }}.Parse({{ quote $hf.Value }}))
+    {{ end }}
+    {{ if ne $method.ApiBodyTemplate "" }}
+    {{ printf "body%sTmpl%s" $.Ident $method.Ident }} = template.Must(template.New("Body{{ $method.Ident }}"){{ if gt (len $additionalFuncs) 0 }}.Funcs(template.FuncMap{ {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }}, {{ end }} }){{ end }}.Parse({{ quote $method.ApiBodyTemplate }}))
+    {{ end }}
+    {{ end }}
+    {{ end }}
+{{ end }}
 )
 
 {{ $getBufferFunc := (printf "__%sGetBuffer" $.Ident) }}
@@ -64,7 +73,7 @@ var (
         {{- end -}}
         {
         __maxRetry := {{ $method.MaxRetry }}
-        {{ if (and (httpMethodHasBody $httpMethod) (not (headerHasBody $method.TmplHeader))) }}
+        {{ if (and (httpMethodHasBody $httpMethod) (not (apiHeaderSpecProvidesBody $method))) }}
             var (
             __reader = any({{- range $index, $ident := $sortIn -}}
                 {{- if eq $index (sub (len $sortIn) 1) -}}
@@ -93,7 +102,7 @@ var (
         {{- $err := printf "err%s" $method.Ident }}
         {{- $err }} error
         )
-        {{ if (and (httpMethodHasBody $httpMethod) (not (headerHasBody $method.TmplHeader))) }}
+        {{ if (and (httpMethodHasBody $httpMethod) (not (apiHeaderSpecProvidesBody $method))) }}
             if __readerCanReset {
             if {{ $err }} = __reset.Reset(); {{ $err }} != nil {
             return {{ range $index, $type := $method.Out -}}
@@ -191,7 +200,6 @@ var (
         {{- $n := printf "n%s" $method.Ident -}}
         {{- $page := printf "page%s" $method.Ident -}}
         {{- $addrTmpl := printf "addr%sTmpl%s" $.Ident $method.Ident -}}
-        {{- $headerTmpl := printf "header%sTmpl%s" $.Ident $method.Ident -}}
         {{- if $method.ReturnSlice }}
             var (
             {{ if gt (len $method.Out) 1 -}}
@@ -214,16 +222,29 @@ var (
                 }).
                 Parse({{ quote ($method.TmplURL) }}),
                 )
-                {{ if ne $method.Header "" -}}
-                    {{ $headerTmpl }} = template.Must(
-                    template.New("Header{{ $method.Ident }}").
+                {{ if or (gt (len $method.ApiHeaderFields) 0) (ne $method.ApiBodyTemplate "") -}}
+                    {{ range $hi, $hf := $method.ApiHeaderFields }}
+                    {{ printf "header%sTmpl%s_%d" $.Ident $method.Ident $hi }} = template.Must(
+                    template.New("Header{{ $method.Ident }}_{{ $hi }}").
                     Funcs(template.FuncMap{
                     "page": {{ $page }},
                     {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }},
                     {{ end }}
                     }).
-                    Parse({{ quote $method.TmplHeader }}),
+                    Parse({{ quote $hf.Value }}),
                     )
+                    {{ end }}
+                    {{ if ne $method.ApiBodyTemplate "" }}
+                    {{ printf "body%sTmpl%s" $.Ident $method.Ident }} = template.Must(
+                    template.New("Body{{ $method.Ident }}").
+                    Funcs(template.FuncMap{
+                    "page": {{ $page }},
+                    {{ range $key, $func := $additionalFuncs }} {{ quote $key }}: {{ $func }},
+                    {{ end }}
+                    }).
+                    Parse({{ quote $method.ApiBodyTemplate }}),
+                    )
+                    {{ end }}
                 {{- end }}
             {{- end }}
             )
@@ -241,7 +262,7 @@ var (
         {{ end }}
 
         {{ $header := printf "header%s" $method.Ident -}}
-        {{ if ne $method.Header "" -}}
+        {{ if or (gt (len $method.ApiHeaderFields) 0) (ne $method.ApiBodyTemplate "") -}}
             {{ if $.HasFeature "api/nort" }}
                 {{ $header }} := {{ $getBufferFunc }}()
                 defer {{ $putBufferFunc }}({{ $header }})
@@ -303,56 +324,34 @@ var (
         fmt.Errorf("error building '{{ $method.Ident }}' url: %w", {{ $err }})
         }
 
-        {{ $bufReader := printf "bufReader%s" $method.Ident }}
-        {{ $mimeHeader := printf "mimeHeader%s" $method.Ident -}}
-        {{ if ne $method.Header "" -}}
-            if {{ $err }} = {{ $headerTmpl }}.Execute({{ $header }}, map[string]any{
-            {{ if $.HasInner -}}
-                "{{ $.Ident }}": __imp.{{ methodInner }}(),
-            {{ end -}}
-            {{ range $index, $ident := $sortIn -}}
-                "{{- $ident }}": {{ $ident -}},
-            {{ end }}
-            }); {{ $err }} != nil {
-            return {{ range $index, $type := $method.Out -}}
-                {{- if lt $index (sub (len $method.Out) 1) -}}
-                    v{{- $index -}}{{- $method.Ident }},
-                {{- end -}}
+        {{ $bodyBytes := printf "bodyBytes%s" $method.Ident -}}
+        {{ if and (httpMethodHasBody $httpMethod) (apiHeaderSpecProvidesBody $method) }}
+        var {{ $bodyBytes }} []byte
+        if {{ $err }} = {{ printf "body%sTmpl%s" $.Ident $method.Ident }}.Execute({{ $header }}, map[string]any{
+        {{ if $.HasInner -}}
+            "{{ $.Ident }}": __imp.{{ methodInner }}(),
+        {{ end -}}
+        {{ range $index, $ident := $sortIn -}}
+            "{{- $ident }}": {{ $ident -}},
+        {{ end }}
+        }); {{ $err }} != nil {
+        return {{ range $index, $type := $method.Out -}}
+            {{- if lt $index (sub (len $method.Out) 1) -}}
+                v{{- $index -}}{{- $method.Ident }},
             {{- end -}}
-            fmt.Errorf("error building '{{ $method.Ident }}' header: %w", {{ $err }})
-            }
-            {{ $bufReader }} := bufio.NewReader({{ $header }})
-            {{ $mimeHeader }}, {{ $err }} := textproto.NewReader({{ $bufReader }}).ReadMIMEHeader()
-            if {{ $err }} != nil {
-            return {{ range $index, $type := $method.Out -}}
-                {{- if lt $index (sub (len $method.Out) 1) -}}
-                    v{{- $index -}}{{- $method.Ident }},
-                {{- end -}}
-            {{- end -}}
-            fmt.Errorf("error reading '{{ $method.Ident }}' header: %w", {{ $err }})
-            }
-        {{- end }}
+        {{- end -}}
+        fmt.Errorf("error building '{{ $method.Ident }}' request body template: %w", {{ $err }})
+        }
+        {{ $bodyBytes }} = append([]byte(nil), {{ $header }}.Bytes()...)
+        {{ $header }}.Reset()
+        {{ end }}
 
         {{ $url := printf "url%s" $method.Ident -}}
         {{ $url }} := {{ $addr }}.String()
         {{- $request := printf "request%s" $method.Ident -}}
         {{- if httpMethodHasBody $httpMethod }}
-            {{- if headerHasBody $method.TmplHeader }}
-                {{- if or ($.HasFeature "api/logx") ($.HasFeature "api/get-body") }}
-                    {{- $body := printf "requestBody%s" $method.Ident }}
-                    {{ $body }}, {{ $err }} := io.ReadAll({{ $bufReader }})
-                    if {{ $err }} != nil {
-                    return {{ range $index, $type := $method.Out -}}
-                        {{- if lt $index (sub (len $method.Out) 1) -}}
-                            v{{- $index -}}{{- $method.Ident }},
-                        {{- end -}}
-                    {{- end -}}
-                    fmt.Errorf("error reading '{{ $method.Ident }}' request body: %w", {{ $err }})
-                    }
-                    {{ $request }}, {{ $err }} := http.NewRequest{{ if $method.HasContext }}WithContext{{ end }}({{ if $method.HasContext }}ctx, {{ end }}{{ quote $httpMethod }}, {{ $url }}, bytes.NewReader({{ $body }}))
-                {{ else }}
-                    {{ $request }}, {{ $err }} := http.NewRequest{{ if $method.HasContext }}WithContext{{ end }}({{ if $method.HasContext }}ctx, {{ end }}{{ quote $httpMethod }}, {{ $url }}, {{ $bufReader }})
-                {{ end -}}
+            {{- if apiHeaderSpecProvidesBody $method }}
+                {{ $request }}, {{ $err }} := http.NewRequest{{ if $method.HasContext }}WithContext{{ end }}({{ if $method.HasContext }}ctx, {{ end }}{{ quote $httpMethod }}, {{ $url }}, bytes.NewReader({{ $bodyBytes }}))
             {{ else }}
                 {{ $request }}, {{ $err }} := http.NewRequest{{ if $method.HasContext }}WithContext{{ end }}({{ if $method.HasContext }}ctx, {{ end }}{{ quote $httpMethod }}, {{ $url }}, {{- range $index, $ident := $sortIn -}}
                     {{- if eq $index (sub (len $sortIn) 1) -}}
@@ -375,15 +374,36 @@ var (
         fmt.Errorf("error building '{{ $method.Ident }}' request: %w", {{ $err }})
         }
 
-        {{ if ne $method.Header "" -}}
-            {{ $k := printf "k%s" $method.Ident -}}
-            {{ $vv := printf "vv%s" $method.Ident -}}
-            {{ $v := printf "v%s" $method.Ident -}}
-            for {{ $k }}, {{ $vv }} := range {{ $mimeHeader }} {
-            for _, {{ $v }} := range {{ $vv }} {
-            {{ $request }}.Header.Add({{ $k }}, {{ $v }})
-            }
-            }
+        {{ if gt (len $method.ApiHeaderFields) 0 -}}
+        {{ range $hi, $hf := $method.ApiHeaderFields }}
+        if {{ $err }} = {{ printf "header%sTmpl%s_%d" $.Ident $method.Ident $hi }}.Execute({{ $header }}, map[string]any{
+        {{ if $.HasInner -}}
+            "{{ $.Ident }}": __imp.{{ methodInner }}(),
+        {{ end -}}
+        {{ range $index, $ident := $sortIn -}}
+            "{{- $ident }}": {{ $ident -}},
+        {{ end }}
+        }); {{ $err }} != nil {
+        return {{ range $index, $type := $method.Out -}}
+            {{- if lt $index (sub (len $method.Out) 1) -}}
+                v{{- $index -}}{{- $method.Ident }},
+            {{- end -}}
+        {{- end -}}
+        fmt.Errorf("error building '{{ $method.Ident }}' header field %s: %w", {{ quote $hf.Name }}, {{ $err }})
+        }
+        {{ $hv := printf "hv%s_%d" $method.Ident $hi }}
+        {{ $hv }} := {{ $header }}.String()
+        if strings.ContainsAny({{ $hv }}, "\r\n\x00") {
+        return {{ range $index, $type := $method.Out -}}
+            {{- if lt $index (sub (len $method.Out) 1) -}}
+                v{{- $index -}}{{- $method.Ident }},
+            {{- end -}}
+        {{- end -}}
+        fmt.Errorf("invalid header value for %s: contains CR, LF, or NUL", {{ quote $hf.Name }})
+        }
+        {{ $request }}.Header.Add({{ quote $hf.Name }}, {{ $hv }})
+        {{ $header }}.Reset()
+        {{ end }}
         {{- end }}
 
         {{ if $.HasFeature "api/gzip" }}
@@ -526,7 +546,7 @@ var (
             }
         {{ end }}
 
-        {{ $addr }}.Reset() {{ if ne $method.Header "" }}
+        {{ $addr }}.Reset() {{ if or (gt (len $method.ApiHeaderFields) 0) (ne $method.ApiBodyTemplate "") }}
             {{ $header }}.Reset(){{ end }}
         {{ if not ($.HasFeature "api/future") }}{{ $responseBody }}.Reset(){{ end }}
 

--- a/gen/testdata/api/test.go
+++ b/gen/testdata/api/test.go
@@ -190,4 +190,15 @@ type SuccessBodyTemplatePost interface {
 	Run(ctx context.Context, x string) error
 }
 
+//go:generate defc [mode] [output] [features...] TestBuildApi/success_body_only
+type SuccessBodyOnly interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run POST https://localhost:port/path
+	//
+	//
+	// {{ .x }}
+	Run(ctx context.Context, x string) error
+}
+
 type Generic[T any, U any] struct{}

--- a/gen/testdata/api/test.go
+++ b/gen/testdata/api/test.go
@@ -147,4 +147,47 @@ type SuccessWithOptions[O any] interface {
 	Run(ctx context.Context) error
 }
 
+//go:generate defc [mode] [output] [features...] TestBuildApi/fail_header_empty_block
+type FailHeaderEmptyBlock interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run GET https://localhost:port/path
+	//
+	//
+	Run(ctx context.Context) error
+}
+
+//go:generate defc [mode] [output] [features...] TestBuildApi/fail_body_template_get
+type FailBodyTemplateGet interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run GET https://localhost:port/path
+	// X-A: 1
+	//
+	// {{ .x }}
+	Run(ctx context.Context, x string) error
+}
+
+//go:generate defc [mode] [output] [features...] TestBuildApi/fail_body_template_head
+type FailBodyTemplateHead interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run HEAD https://localhost:port/path
+	// X-A: 1
+	//
+	// {{ .x }}
+	Run(ctx context.Context, x string) error
+}
+
+//go:generate defc [mode] [output] [features...] TestBuildApi/success_body_template_post
+type SuccessBodyTemplatePost interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run POST https://localhost:port/path
+	// Content-Type: application/json
+	//
+	// {{ .x }}
+	Run(ctx context.Context, x string) error
+}
+
 type Generic[T any, U any] struct{}

--- a/gen/testdata/api/test.go
+++ b/gen/testdata/api/test.go
@@ -201,4 +201,12 @@ type SuccessBodyOnly interface {
 	Run(ctx context.Context, x string) error
 }
 
+//go:generate defc [mode] [output] [features...] TestBuildApi/success_gzip_no_headers
+type SuccessGzipNoHeaders interface {
+	Response() Generic[defc.Response, defc.FutureResponse]
+
+	// Run GET https://localhost:port/path
+	Run(ctx context.Context) error
+}
+
 type Generic[T any, U any] struct{}


### PR DESCRIPTION
## Summary
- Parse API header comments into static header fields plus a separate body template at generation time.
- Render header values individually and reject CR, LF, or NUL before `Header.Add`.
- Remove generated `bufio`/`net/textproto` MIME parsing path and add #18 regression coverage.

## Tests
- `git diff --check`
- `go test ./gen ./gen/integration ./runtime ./runtime/token ./sqlx ./sqlx/reflectx`

Fixes #18
